### PR TITLE
fix: 複数ディレクトリ監視時のクロスマッチバグを修正

### DIFF
--- a/cat-watcher/src/router.rs
+++ b/cat-watcher/src/router.rs
@@ -76,6 +76,13 @@ fn evaluate_rule(path: &Path, detected_events: &HashSet<Event>, rule: &CompiledR
     if !matches_target(path, &rule.target) { return false; }
     if !matches_hidden(path, rule.include_hidden) { return false; }
 
+    let watch_path = Path::new(&rule.watch_path);
+    if rule.recursive {
+        if !path.starts_with(watch_path) { return false; }
+    } else {
+        if path.parent() != Some(watch_path) { return false; }
+    }
+
     let file_name = match path.file_name().and_then(|n| n.to_str()) {
 		Some(name) => name,
 		None => return false, // ファイル名が UTF-8 でない場合はルール不適用

--- a/cat-watcher/src/router.rs
+++ b/cat-watcher/src/router.rs
@@ -218,3 +218,113 @@ pub async fn run_router(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use tempfile::TempDir;
+
+    fn make_rule(watch_path: &str, recursive: bool, patterns: Option<Vec<&str>>) -> CompiledRule {
+        let glob_set = patterns.map(|pats| {
+            let mut builder = GlobSetBuilder::new();
+            for p in pats {
+                builder.add(Glob::new(p).unwrap());
+            }
+            builder.build().unwrap()
+        });
+        CompiledRule {
+            name: format!("rule-{}", watch_path),
+            enabled: true,
+            watch_path: watch_path.to_string(),
+            recursive,
+            target: WatchTarget::Both,
+            include_hidden: false,
+            events: vec![Event::Create],
+            glob_set,
+            exclude_glob_set: None,
+            regexes: None,
+            actions: vec![],
+        }
+    }
+
+    fn create_events(e: Event) -> HashSet<Event> {
+        let mut s = HashSet::new();
+        s.insert(e);
+        s
+    }
+
+    // 2つの監視ディレクトリを用意し、片方で検知したファイルが
+    // もう片方のルールに誤マッチしないことを確認する（バグ再現テスト）
+    #[test]
+    fn test_no_cross_directory_match() {
+        let dir_a = TempDir::new().unwrap();
+        let dir_b = TempDir::new().unwrap();
+
+        let rule_a = make_rule(dir_a.path().to_str().unwrap(), false, Some(vec!["*.csv"]));
+        let rule_b = make_rule(dir_b.path().to_str().unwrap(), false, Some(vec!["*.csv"]));
+
+        let file_in_a = dir_a.path().join("data.csv");
+        std::fs::write(&file_in_a, "").unwrap();
+        let events = create_events(Event::Create);
+
+        assert!(evaluate_rule(&file_in_a, &events, &rule_a), "dir_a のルールはマッチすべき");
+        assert!(!evaluate_rule(&file_in_a, &events, &rule_b), "dir_b のルールはマッチしてはいけない");
+    }
+
+    // recursive=false でサブディレクトリのファイルが除外されることを確認
+    #[test]
+    fn test_non_recursive_excludes_subdir() {
+        let dir = TempDir::new().unwrap();
+        let subdir = dir.path().join("sub");
+        std::fs::create_dir(&subdir).unwrap();
+        let file_in_sub = subdir.join("data.csv");
+        std::fs::write(&file_in_sub, "").unwrap();
+
+        let rule = make_rule(dir.path().to_str().unwrap(), false, Some(vec!["*.csv"]));
+        let events = create_events(Event::Create);
+
+        assert!(!evaluate_rule(&file_in_sub, &events, &rule), "サブディレクトリのファイルはマッチしてはいけない");
+    }
+
+    // recursive=true ではサブディレクトリのファイルもマッチすることを確認
+    #[test]
+    fn test_recursive_includes_subdir() {
+        let dir = TempDir::new().unwrap();
+        let subdir = dir.path().join("sub");
+        std::fs::create_dir(&subdir).unwrap();
+        let file_in_sub = subdir.join("data.csv");
+        std::fs::write(&file_in_sub, "").unwrap();
+
+        let rule = make_rule(dir.path().to_str().unwrap(), true, Some(vec!["*.csv"]));
+        let events = create_events(Event::Create);
+
+        assert!(evaluate_rule(&file_in_sub, &events, &rule), "recursive=true ならサブディレクトリもマッチすべき");
+    }
+
+    // 直下のファイルは recursive=false でもマッチすることを確認
+    #[test]
+    fn test_non_recursive_matches_direct_child() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("data.csv");
+        std::fs::write(&file, "").unwrap();
+
+        let rule = make_rule(dir.path().to_str().unwrap(), false, Some(vec!["*.csv"]));
+        let events = create_events(Event::Create);
+
+        assert!(evaluate_rule(&file, &events, &rule));
+    }
+
+    // パターンに合わないファイルは除外されることを確認
+    #[test]
+    fn test_pattern_mismatch_excluded() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("image.png");
+        std::fs::write(&file, "").unwrap();
+
+        let rule = make_rule(dir.path().to_str().unwrap(), false, Some(vec!["*.csv"]));
+        let events = create_events(Event::Create);
+
+        assert!(!evaluate_rule(&file, &events, &rule));
+    }
+}


### PR DESCRIPTION
## 問題

2つのディレクトリを `recursive = false` で監視する設定のとき、片方のディレクトリで検知したファイルが、もう片方のルールにも誤ってマッチしてしまうバグがあった。

例：
- `rule-A` が `/watch_a` を監視
- `rule-B` が `/watch_b` を監視
- `/watch_a/data.csv` を作成すると `rule-A` と `rule-B` の両方が発火
- `rule-B` はパスが `/watch_b` でないためアクションでエラーが発生

## 原因

`router.rs` の `evaluate_rule()` 関数が、検知したファイルパスがルールの `watch_path` 配下かどうかを**検証していなかった**。ファイル名パターンのみで評価していたため、異なるディレクトリのルールにもマッチしてしまっていた。

## 修正内容

`evaluate_rule()` にパス境界チェックを追加（`router.rs`）。

```rust
let watch_path = Path::new(&rule.watch_path);
if rule.recursive {
    if !path.starts_with(watch_path) { return false; }
} else {
    if path.parent() != Some(watch_path) { return false; }
}
```

- `recursive = true`：パスが `watch_path` 配下であることを確認
- `recursive = false`：親ディレクトリが `watch_path` と完全一致することを確認

## テスト

### ユニットテスト（`router::tests`、5件追加）

| テスト | 内容 |
|--------|------|
| `test_no_cross_directory_match` | バグ再現：異なるディレクトリ間で誤マッチしない |
| `test_non_recursive_excludes_subdir` | `recursive=false` でサブディレクトリを除外 |
| `test_recursive_includes_subdir` | `recursive=true` でサブディレクトリを含む |
| `test_non_recursive_matches_direct_child` | 直下ファイルは正常マッチ |
| `test_pattern_mismatch_excluded` | パターン不一致は除外 |

### 実行テスト（バイナリで動作確認）

実際にビルドしたバイナリを使い、2ディレクトリ設定で動作確認済み。

| ケース | 期待 | 結果 |
|--------|------|------|
| `watch_a` にファイル作成 | `rule-A` のみ発火 | ✅ |
| `watch_b` にファイル作成 | `rule-B` のみ発火 | ✅ |