### PR TITLE
v1.0.0 リリース

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cat-watcher"
-version = "0.1.1"
+version = "1.0.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -151,8 +151,9 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "walkdir",
+ "winres",
 ]
 
 [[package]]
@@ -832,6 +833,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -1233,6 +1243,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winres"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
+dependencies = [
+ "toml 0.5.11",
 ]
 
 [[package]]

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-watcher"
-version = "0.1.1"
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]
@@ -16,6 +16,9 @@ tokio = { version = "1.51.1", features = ["rt-multi-thread", "macros", "sync", "
 blake3 = "1"
 walkdir = "2"
 colored = "2"
+
+[build-dependencies]
+winres = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/cat-watcher/build.rs
+++ b/cat-watcher/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        let mut res = winres::WindowsResource::new();
+        res.set("FileDescription", "ファイル監視・自動処理ツール");
+        res.set("ProductName", "cat-watcher");
+        res.set("LegalCopyright", "Copyright \u{00a9} 2026 capypara20");
+        res.compile().expect("Windows リソースのコンパイルに失敗");
+    }
+}


### PR DESCRIPTION
## v1.0.0 リリース

### 新機能
- **`log` アクション**: コマンド実行なしにイベントをログファイルへ記録
- **`--init` コマンド**: `global.toml` / `rules.toml` / `rules.csv` のテンプレートを生成
- **バリデーション全件報告**: 設定ファイルに複数の問題があっても1回で全エラーを表示
- **大文字小文字不区別**: `create` / `Create` / `CREATE` のいずれでも動作
- **アクション実行前のパス存在チェック**: `working_dir` / `program` の存在をバリデーション時に検証
- **Windows 実行ファイルへのバージョン情報埋め込み**: エクスプローラーの「プロパティ→詳細」にバージョン・製品名・著作権を表示

### 改善
- ログの `\\?\` UNC プレフィックスを除去（パス表示がすっきり）
- `log_rotation = "never"` を実際に反映（これまで設定値が無視されていた）
- バリデーション構造をエラー全件収集型にリファクタリング
- コンパイラ警告ゼロ化

### 削除
- `csv2toml` 独立クレート（`--from-csv` / `--init csv` として本体に吸収済み）
- `.github/skills/`、`doc/設計下書き/` 等の不要ファイル

### バージョン
`0.1.1` → `1.0.0`

main へのマージ後、CI が自動で `v1.0.0` タグを作成し Windows / Linux バイナリを Releases に公開します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5fbeHZYTfs1g74TGQ4X1V)_