### PR TITLE
fix: rename 操作を Rename イベントとして検知 (Closes #30)

### DIFF
--- a/cat-watcher/src/router.rs
+++ b/cat-watcher/src/router.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
 use notify::EventKind;
-use notify::event::{CreateKind, RemoveKind};
+use notify::event::{CreateKind, ModifyKind, RemoveKind};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
 use crate::{config::{ActionConfig, Event, Global, Rule, WatchTarget}, error::AppError};
@@ -199,6 +199,9 @@ fn matches_events(detected: &HashSet<Event>, rule_events: &[Event]) -> bool {
 fn to_config_event(kind:  &EventKind) -> Option<Event> {
 	match kind {
 		EventKind::Create(_) => Some(Event::Create),
+		// notify はリネームを EventKind::Modify(ModifyKind::Name(_)) として通知するため、
+		// 通常の Modify と区別して Event::Rename にマッピングする
+		EventKind::Modify(ModifyKind::Name(_)) => Some(Event::Rename),
 		EventKind::Modify(_) => Some(Event::Modify),
 		EventKind::Remove(_) => Some(Event::Delete),
 		_ => None,
@@ -628,5 +631,36 @@ mod tests {
         );
         let events = create_events(Event::Delete);
         assert!(!evaluate_rule(&path, &events, Some(EntryKind::Dir), &rule));
+    }
+
+    // -----------------------------------------------------------------
+    // to_config_event: Rename マッピング (issue #30 回帰テスト)
+    // -----------------------------------------------------------------
+    use notify::event::RenameMode;
+
+    #[test]
+    fn test_to_config_event_rename_from() {
+        let kind = EventKind::Modify(ModifyKind::Name(RenameMode::From));
+        assert_eq!(to_config_event(&kind), Some(Event::Rename));
+    }
+
+    #[test]
+    fn test_to_config_event_rename_to() {
+        let kind = EventKind::Modify(ModifyKind::Name(RenameMode::To));
+        assert_eq!(to_config_event(&kind), Some(Event::Rename));
+    }
+
+    #[test]
+    fn test_to_config_event_rename_any() {
+        let kind = EventKind::Modify(ModifyKind::Name(RenameMode::Any));
+        assert_eq!(to_config_event(&kind), Some(Event::Rename));
+    }
+
+    // Rename 以外の Modify は引き続き Modify として扱う
+    #[test]
+    fn test_to_config_event_modify_data_still_modify() {
+        use notify::event::{DataChange, ModifyKind};
+        let kind = EventKind::Modify(ModifyKind::Data(DataChange::Content));
+        assert_eq!(to_config_event(&kind), Some(Event::Modify));
     }
 }


### PR DESCRIPTION
## Summary

- `to_config_event()` で `EventKind::Modify(ModifyKind::Name(_))` を `Event::Rename` にマッピング
- これまで rename 操作はすべて Modify に潰されていたため、`events = ["rename"]` 設定が機能していなかった
- router.rs に回帰テスト4件を追加 (Rename From/To/Any、および Modify(Data) が引き続き Modify になること)

## Test plan

- [x] `cargo test --package cat-watcher` で 128 件全パス (回帰なし)
- [x] Win11 ローカル C ドライブで実機検証 (`tool/Run-CatWatcherTest.ps1`)
  - 修正前: `test1.txt -> test1_renamed.txt` の操作が `Modify` として記録される
  - 修正後: 同操作が `Rename` として記録されることをログで確認
- [x] 他のイベント (Create / Modify / Delete) と `target=file` / `target=directory` / recursive の動作も合わせて確認、回帰なし

## 実機ログ抜粋 (修正後)

```
2026-05-17 21:59:08 │ MATCH   │ Rename                      │ C:\catwatcher-test\watch\test1_renamed.txt
2026-05-17 21:59:08 │ MATCH   │ Rename                      │ C:\catwatcher-test\watch\test1.txt
```

## Base ブランチについて

PR #29 (`claude/raw-events-observer-Htqht`) 起点で作成。
PR #29 がマージされたら自動的に main から見えるようになる前提。

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>