### PR TITLE
fix: Delete/Rename イベントの種別判定を修正 (#23 #24 #30)

### DIFF
--- a/cat-watcher/build.rs
+++ b/cat-watcher/build.rs
@@ -4,6 +4,13 @@ fn main() {
         res.set("FileDescription", "ファイル監視・自動処理ツール");
         res.set("ProductName", "cat-watcher");
         res.set("LegalCopyright", "Copyright \u{00a9} 2026 capypara20");
+        // Linux クロスコンパイル時は mingw の windres を使う
+        if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+            && std::env::consts::OS != "windows"
+        {
+            res.set_windres_path("x86_64-w64-mingw32-windres");
+            res.set_ar_path("x86_64-w64-mingw32-ar");
+        }
         res.compile().expect("Windows リソースのコンパイルに失敗");
     }
 }

--- a/cat-watcher/src/router.rs
+++ b/cat-watcher/src/router.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
 use notify::EventKind;
-use notify::event::{CreateKind, RemoveKind};
+use notify::event::{CreateKind, ModifyKind, RemoveKind};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
 use crate::{config::{ActionConfig, Event, Global, Rule, WatchTarget}, error::AppError};
@@ -176,6 +176,9 @@ fn matches_events(detected: &HashSet<Event>, rule_events: &[Event]) -> bool {
 fn to_config_event(kind:  &EventKind) -> Option<Event> {
 	match kind {
 		EventKind::Create(_) => Some(Event::Create),
+		// notify はリネームを EventKind::Modify(ModifyKind::Name(_)) として通知するため、
+		// 通常の Modify と区別して Event::Rename にマッピングする
+		EventKind::Modify(ModifyKind::Name(_)) => Some(Event::Rename),
 		EventKind::Modify(_) => Some(Event::Modify),
 		EventKind::Remove(_) => Some(Event::Delete),
 		_ => None,
@@ -589,5 +592,36 @@ mod tests {
         );
         let events = create_events(Event::Delete);
         assert!(!evaluate_rule(&path, &events, Some(EntryKind::Dir), &rule));
+    }
+
+    // -----------------------------------------------------------------
+    // to_config_event: Rename マッピング (issue #30 回帰テスト)
+    // -----------------------------------------------------------------
+    use notify::event::RenameMode;
+
+    #[test]
+    fn test_to_config_event_rename_from() {
+        let kind = EventKind::Modify(ModifyKind::Name(RenameMode::From));
+        assert_eq!(to_config_event(&kind), Some(Event::Rename));
+    }
+
+    #[test]
+    fn test_to_config_event_rename_to() {
+        let kind = EventKind::Modify(ModifyKind::Name(RenameMode::To));
+        assert_eq!(to_config_event(&kind), Some(Event::Rename));
+    }
+
+    #[test]
+    fn test_to_config_event_rename_any() {
+        let kind = EventKind::Modify(ModifyKind::Name(RenameMode::Any));
+        assert_eq!(to_config_event(&kind), Some(Event::Rename));
+    }
+
+    // Rename 以外の Modify は引き続き Modify として扱う
+    #[test]
+    fn test_to_config_event_modify_data_still_modify() {
+        use notify::event::{DataChange, ModifyKind};
+        let kind = EventKind::Modify(ModifyKind::Data(DataChange::Content));
+        assert_eq!(to_config_event(&kind), Some(Event::Modify));
     }
 }

--- a/cat-watcher/src/router.rs
+++ b/cat-watcher/src/router.rs
@@ -6,10 +6,31 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
 use notify::EventKind;
+use notify::event::{CreateKind, RemoveKind};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
 use crate::{config::{ActionConfig, Event, Global, Rule, WatchTarget}, error::AppError};
 use crate::logger::Logger;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    File,
+    Dir,
+}
+
+/// notify のイベントサブタイプから EntryKind を取得する。
+/// Linux は File/Folder が明確に来る。Windows は Any なので None を返す。
+fn kind_from_notify_event(event: &notify::Event) -> Option<EntryKind> {
+    match &event.kind {
+        EventKind::Create(CreateKind::File) | EventKind::Remove(RemoveKind::File) => {
+            Some(EntryKind::File)
+        }
+        EventKind::Create(CreateKind::Folder) | EventKind::Remove(RemoveKind::Folder) => {
+            Some(EntryKind::Dir)
+        }
+        _ => None,
+    }
+}
 
 pub struct CompiledRule{
 	pub name: String,
@@ -73,9 +94,14 @@ pub fn compile_rules(rules: &[Rule]) -> Result<Vec<CompiledRule>, AppError> {
 	Ok(compiled_rules)
 }
 
-fn evaluate_rule(path: &Path, detected_events: &HashSet<Event>, rule: &CompiledRule) -> bool {
+fn evaluate_rule(
+    path: &Path,
+    detected_events: &HashSet<Event>,
+    kind: Option<EntryKind>,
+    rule: &CompiledRule,
+) -> bool {
 	if !rule.enabled { return false; }
-    if !matches_target(path, &rule.target) { return false; }
+    if !matches_target(path, &rule.target, kind) { return false; }
     if !matches_hidden(path, rule.include_hidden) { return false; }
 
     let watch_path = Path::new(&rule.watch_path);
@@ -97,15 +123,20 @@ fn evaluate_rule(path: &Path, detected_events: &HashSet<Event>, rule: &CompiledR
 }
 
 /// target フィルタ: file/directory/both の判定
-fn matches_target(path: &Path, target: &WatchTarget) -> bool{
-	match target {
-		WatchTarget::Both => true, // ターゲットが両方なら常にマッチ
-		WatchTarget::File => path.is_file(), // ファイルであればマッチ
-		WatchTarget::Directory => path.is_dir(), // ディレクトリであればマッチ
-		// TODO: deleteイベント時はファイルが存在しないため判定不可
-		// 		 notify の EventKindから指定すれば判定可能かも
-		
-	}
+///
+/// kind はイベント受信時点でキャッシュ or notify サブタイプから解決済み。
+/// Delete 後はパスが消えているため is_file()/is_dir() が使えないが、
+/// kind が Some であればキャッシュ由来の情報で正しく判定できる。
+fn matches_target(path: &Path, target: &WatchTarget, kind: Option<EntryKind>) -> bool {
+    match target {
+        WatchTarget::Both => true,
+        WatchTarget::File => kind
+            .map(|k| k == EntryKind::File)
+            .unwrap_or_else(|| path.is_file()),
+        WatchTarget::Directory => kind
+            .map(|k| k == EntryKind::Dir)
+            .unwrap_or_else(|| path.is_dir()),
+    }
 }
 
 /// include_hidden フィルタ（Phase 12 まではスタブ）
@@ -155,9 +186,10 @@ pub async fn run_router(
     compiled_rules: &[CompiledRule],
     global: &Global,
     log: Arc<Logger>,
+    mut path_cache: HashMap<PathBuf, EntryKind>,
 ) -> Result<(), AppError> {
-    // デバウンス用マップ: パス → (イベント集合, 最後の受信時刻)
-    let mut pending: HashMap<PathBuf, (HashSet<Event>, Instant)> = HashMap::new();
+    // デバウンス用マップ: パス → (イベント集合, 最後の受信時刻, EntryKind)
+    let mut pending: HashMap<PathBuf, (HashSet<Event>, Instant, Option<EntryKind>)> = HashMap::new();
     let mut interval = tokio::time::interval(Duration::from_millis(100));
 
     loop {
@@ -165,13 +197,37 @@ pub async fn run_router(
             // (A) watcher からイベント受信 → pending に蓄積
             Some(res) = rx.recv() => {
                 if let Ok(event) = res {
+                    // Create 時はパスがまだ存在するのでキャッシュ更新できる
+                    if matches!(event.kind, EventKind::Create(_)) {
+                        for path in &event.paths {
+                            if path.is_file() {
+                                path_cache.insert(path.clone(), EntryKind::File);
+                            } else if path.is_dir() {
+                                path_cache.insert(path.clone(), EntryKind::Dir);
+                            }
+                        }
+                    }
+
+                    // notify サブタイプ優先、なければキャッシュ参照（Windows 対応）
+                    let notify_kind = kind_from_notify_event(&event);
+
                     if let Some(config_event) = to_config_event(&event.kind) {
                         for path in &event.paths {
+                            let kind = notify_kind.or_else(|| path_cache.get(path).copied());
+
+                            // Remove 時はキャッシュから削除（kind は取得済み）
+                            if matches!(event.kind, EventKind::Remove(_)) {
+                                path_cache.remove(path);
+                            }
+
                             let entry = pending
                                 .entry(path.clone())
-                                .or_insert_with(|| (HashSet::new(), Instant::now()));
+                                .or_insert_with(|| (HashSet::new(), Instant::now(), kind));
                             entry.0.insert(config_event.clone());
                             entry.1 = Instant::now();
+                            if entry.2.is_none() {
+                                entry.2 = kind;
+                            }
                         }
                     }
                 }
@@ -180,15 +236,15 @@ pub async fn run_router(
             // (B) 100ms タイマー → 500ms 経過分を取り出して評価
             _ = interval.tick() => {
                 let now = Instant::now();
-                let ready: Vec<(PathBuf, HashSet<Event>)> = pending.iter()
-                    .filter(|(_, (_, last))| now.duration_since(*last) >= Duration::from_millis(500))
-                    .map(|(path, (events, _))| (path.clone(), events.clone()))
+                let ready: Vec<(PathBuf, HashSet<Event>, Option<EntryKind>)> = pending.iter()
+                    .filter(|(_, (_, last, _))| now.duration_since(*last) >= Duration::from_millis(500))
+                    .map(|(path, (events, _, kind))| (path.clone(), events.clone(), *kind))
                     .collect();
 
-                for (path, detected_events) in ready {
+                for (path, detected_events, kind) in ready {
                     pending.remove(&path);
                     for rule in compiled_rules {
-                        if !evaluate_rule(&path, &detected_events, rule) {
+                        if !evaluate_rule(&path, &detected_events, kind, rule) {
                             continue;
                         }
 
@@ -274,8 +330,8 @@ mod tests {
         std::fs::write(&file_in_a, "").unwrap();
         let events = create_events(Event::Create);
 
-        assert!(evaluate_rule(&file_in_a, &events, &rule_a), "dir_a のルールはマッチすべき");
-        assert!(!evaluate_rule(&file_in_a, &events, &rule_b), "dir_b のルールはマッチしてはいけない");
+        assert!(evaluate_rule(&file_in_a, &events, None, &rule_a), "dir_a のルールはマッチすべき");
+        assert!(!evaluate_rule(&file_in_a, &events, None, &rule_b), "dir_b のルールはマッチしてはいけない");
     }
 
     // recursive=false でサブディレクトリのファイルが除外されることを確認
@@ -290,7 +346,7 @@ mod tests {
         let rule = make_rule(dir.path().to_str().unwrap(), false, Some(vec!["*.csv"]));
         let events = create_events(Event::Create);
 
-        assert!(!evaluate_rule(&file_in_sub, &events, &rule), "サブディレクトリのファイルはマッチしてはいけない");
+        assert!(!evaluate_rule(&file_in_sub, &events, None, &rule), "サブディレクトリのファイルはマッチしてはいけない");
     }
 
     // recursive=true ではサブディレクトリのファイルもマッチすることを確認
@@ -305,7 +361,7 @@ mod tests {
         let rule = make_rule(dir.path().to_str().unwrap(), true, Some(vec!["*.csv"]));
         let events = create_events(Event::Create);
 
-        assert!(evaluate_rule(&file_in_sub, &events, &rule), "recursive=true ならサブディレクトリもマッチすべき");
+        assert!(evaluate_rule(&file_in_sub, &events, None, &rule), "recursive=true ならサブディレクトリもマッチすべき");
     }
 
     // 直下のファイルは recursive=false でもマッチすることを確認
@@ -318,7 +374,7 @@ mod tests {
         let rule = make_rule(dir.path().to_str().unwrap(), false, Some(vec!["*.csv"]));
         let events = create_events(Event::Create);
 
-        assert!(evaluate_rule(&file, &events, &rule));
+        assert!(evaluate_rule(&file, &events, None, &rule));
     }
 
     // パターンに合わないファイルは除外されることを確認
@@ -331,6 +387,6 @@ mod tests {
         let rule = make_rule(dir.path().to_str().unwrap(), false, Some(vec!["*.csv"]));
         let events = create_events(Event::Create);
 
-        assert!(!evaluate_rule(&file, &events, &rule));
+        assert!(!evaluate_rule(&file, &events, None, &rule));
     }
 }

--- a/cat-watcher/src/router.rs
+++ b/cat-watcher/src/router.rs
@@ -125,17 +125,18 @@ fn evaluate_rule(
 /// target フィルタ: file/directory/both の判定
 ///
 /// kind はイベント受信時点でキャッシュ or notify サブタイプから解決済み。
-/// Delete 後はパスが消えているため is_file()/is_dir() が使えないが、
-/// kind が Some であればキャッシュ由来の情報で正しく判定できる。
+/// Delete 後はパスが消えているため is_file()/is_dir() が false になるが、
+/// その場合は kind=None かつ !path.exists() → 判別不能なので通過させる。
+/// (旧 Windows の Remove(Any) でキャッシュミスが発生しても Delete を検知できるようにするため)
 fn matches_target(path: &Path, target: &WatchTarget, kind: Option<EntryKind>) -> bool {
     match target {
         WatchTarget::Both => true,
         WatchTarget::File => kind
             .map(|k| k == EntryKind::File)
-            .unwrap_or_else(|| path.is_file()),
+            .unwrap_or_else(|| path.is_file() || !path.exists()),
         WatchTarget::Directory => kind
             .map(|k| k == EntryKind::Dir)
-            .unwrap_or_else(|| path.is_dir()),
+            .unwrap_or_else(|| path.is_dir() || !path.exists()),
     }
 }
 
@@ -388,5 +389,205 @@ mod tests {
         let events = create_events(Event::Create);
 
         assert!(!evaluate_rule(&file, &events, None, &rule));
+    }
+
+    fn make_rule_with_target_and_events(
+        watch_path: &str,
+        target: WatchTarget,
+        events: Vec<Event>,
+    ) -> CompiledRule {
+        CompiledRule {
+            name: "test-rule".to_string(),
+            enabled: true,
+            watch_path: watch_path.to_string(),
+            recursive: true,
+            target,
+            include_hidden: false,
+            events,
+            glob_set: None,
+            exclude_glob_set: None,
+            regexes: None,
+            actions: vec![],
+        }
+    }
+
+    // ── Issue #23 回帰テスト: target=file + delete ────────────────────────────
+
+    // kind=File が明示的に渡された場合、削除後でも target=file にマッチする
+    #[test]
+    fn test_delete_file_with_kind_file_matches_target_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.csv");
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::File,
+            vec![Event::Delete],
+        );
+        let events = create_events(Event::Delete);
+        // ファイルは削除済み (path が存在しない) だが kind=File があるのでマッチする
+        assert!(evaluate_rule(&path, &events, Some(EntryKind::File), &rule));
+    }
+
+    // kind=Dir が来た場合、target=file にはマッチしない
+    #[test]
+    fn test_delete_dir_does_not_match_target_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("subdir");
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::File,
+            vec![Event::Delete],
+        );
+        let events = create_events(Event::Delete);
+        assert!(!evaluate_rule(&path, &events, Some(EntryKind::Dir), &rule));
+    }
+
+    // kind=None かつパスが存在しない場合 (旧 Windows 無キャッシュ / Delete 後) はマッチする
+    // ファイルか ディレクトリかを区別できないが、削除済みパスは通過させて false negative を防ぐ
+    #[test]
+    fn test_delete_no_kind_no_path_matches_target_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("ghost.txt"); // 存在しないパス (削除済み想定)
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::File,
+            vec![Event::Delete],
+        );
+        let events = create_events(Event::Delete);
+        // kind=None かつ path が存在しない → 判別不能なので通過 (target=file も target=dir も true)
+        assert!(evaluate_rule(&path, &events, None, &rule));
+    }
+
+    // target=dir + kind=Dir → マッチする
+    #[test]
+    fn test_delete_dir_with_kind_dir_matches_target_dir() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("removed_dir");
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::Directory,
+            vec![Event::Delete],
+        );
+        let events = create_events(Event::Delete);
+        assert!(evaluate_rule(&path, &events, Some(EntryKind::Dir), &rule));
+    }
+
+    // target=dir + kind=File → マッチしない
+    #[test]
+    fn test_delete_file_does_not_match_target_dir() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.csv");
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::Directory,
+            vec![Event::Delete],
+        );
+        let events = create_events(Event::Delete);
+        assert!(!evaluate_rule(&path, &events, Some(EntryKind::File), &rule));
+    }
+
+    // target=both + kind=File → マッチする
+    #[test]
+    fn test_delete_file_matches_target_both() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.csv");
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::Both,
+            vec![Event::Delete],
+        );
+        let events = create_events(Event::Delete);
+        assert!(evaluate_rule(&path, &events, Some(EntryKind::File), &rule));
+    }
+
+    // ── Issue #24 回帰テスト: target=both + delete で親ディレクトリが誤マッチしない ──
+
+    // ファイル削除後に親ディレクトリが Modify だけ受け取った場合、
+    // events=["delete"] ルールにマッチしないこと
+    #[test]
+    fn test_parent_dir_modify_does_not_match_delete_rule() {
+        let dir = TempDir::new().unwrap();
+        let parent = dir.path().to_path_buf(); // 親ディレクトリ自身のパス
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::Both,
+            vec![Event::Delete],
+        );
+        // 親ディレクトリは Modify のみ蓄積（ファイル削除の副作用）
+        let events = create_events(Event::Modify);
+        assert!(!evaluate_rule(&parent, &events, Some(EntryKind::Dir), &rule));
+    }
+
+    // Modify と Delete が混在している場合は Delete ルールにマッチする
+    #[test]
+    fn test_mixed_modify_delete_events_matches_delete_rule() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.csv");
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::Both,
+            vec![Event::Delete],
+        );
+        let mut events = HashSet::new();
+        events.insert(Event::Modify);
+        events.insert(Event::Delete);
+        assert!(evaluate_rule(&path, &events, Some(EntryKind::File), &rule));
+    }
+
+    // 親ディレクトリが Modify のみ、events=["delete","modify"] の場合はマッチする
+    // (これは仕様通りの動作 — modify も監視対象なので)
+    #[test]
+    fn test_parent_dir_modify_matches_when_modify_in_rule() {
+        let dir = TempDir::new().unwrap();
+        let parent = dir.path().to_path_buf();
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::Both,
+            vec![Event::Delete, Event::Modify],
+        );
+        let events = create_events(Event::Modify);
+        assert!(evaluate_rule(&parent, &events, Some(EntryKind::Dir), &rule));
+    }
+
+    // rm -r: ディレクトリ内ファイルが Remove(File) で来た場合、target=file にマッチ
+    #[test]
+    fn test_rm_r_inner_file_matches_target_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("subdir").join("inner.txt");
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::File,
+            vec![Event::Delete],
+        );
+        let events = create_events(Event::Delete);
+        assert!(evaluate_rule(&path, &events, Some(EntryKind::File), &rule));
+    }
+
+    // rm -r: ディレクトリ自体が Remove(Folder) で来た場合、target=dir にマッチ
+    #[test]
+    fn test_rm_r_dir_matches_target_dir() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("subdir");
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::Directory,
+            vec![Event::Delete],
+        );
+        let events = create_events(Event::Delete);
+        assert!(evaluate_rule(&path, &events, Some(EntryKind::Dir), &rule));
+    }
+
+    // rm -r: ディレクトリ自体が Remove(Folder) で来た場合、target=file にはマッチしない
+    #[test]
+    fn test_rm_r_dir_does_not_match_target_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("subdir");
+        let rule = make_rule_with_target_and_events(
+            dir.path().to_str().unwrap(),
+            WatchTarget::File,
+            vec![Event::Delete],
+        );
+        let events = create_events(Event::Delete);
+        assert!(!evaluate_rule(&path, &events, Some(EntryKind::Dir), &rule));
     }
 }

--- a/cat-watcher/src/watcher.rs
+++ b/cat-watcher/src/watcher.rs
@@ -4,10 +4,38 @@ use std::sync::Arc;
 
 use notify::{recommended_watcher, Event, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
+use walkdir::WalkDir;
 
 use crate::config::{Global, Rule};
 use crate::error::AppError;
 use crate::logger::Logger;
+use crate::router::EntryKind;
+
+/// ウォッチ対象を walk して EntryKind キャッシュを初期構築する。
+/// 監視開始前から存在するファイル/ディレクトリを Delete 時に識別するために使う。
+fn build_initial_cache(watch_map: &HashMap<PathBuf, RecursiveMode>) -> HashMap<PathBuf, EntryKind> {
+    let mut cache = HashMap::new();
+    for (path, mode) in watch_map {
+        let max_depth = if *mode == RecursiveMode::Recursive {
+            usize::MAX
+        } else {
+            1
+        };
+        for entry in WalkDir::new(path)
+            .max_depth(max_depth)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let p = entry.path().to_path_buf();
+            if entry.file_type().is_file() {
+                cache.insert(p, EntryKind::File);
+            } else if entry.file_type().is_dir() {
+                cache.insert(p, EntryKind::Dir);
+            }
+        }
+    }
+    cache
+}
 
 fn strip_unc_prefix(path: &PathBuf) -> String {
     let s = path.display().to_string();
@@ -89,7 +117,9 @@ pub async fn start_watching(
         })?;
     }
 
+    let initial_cache = build_initial_cache(&watch_map);
+
     let compiled_rules = crate::router::compile_rules(rules)?;
-    crate::router::run_router(rx, &compiled_rules, global, Arc::clone(&log)).await?;
+    crate::router::run_router(rx, &compiled_rules, global, Arc::clone(&log), initial_cache).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Windows 上で削除イベント (\`EventKind::Remove(_)\`) のファイル/フォルダ種別判定が
正しく動作せず、target=file / target=directory ルールが削除を取りこぼす問題、
および rename 操作が Rename イベントとして検知されない問題を解決する。

## 含まれる修正

### #23 / #24: Delete イベントのファイル/ディレクトリ種別判定
- \`router.rs\` に \`EntryKind\` を導入し、Create 時にパスキャッシュを構築。
  Remove 時はキャッシュから種別を解決して target=file / target=directory の
  判定を正しく行う。
- 旧 Windows (ReadDirectoryChangesExW 非対応) では Remove(Any) しか届かないため、
  起動時 walk + Create イベント時の \`is_file()/is_dir()\` でパス種別キャッシュを
  事前構築する。
- Linux では notify サブタイプ (RemoveKind::File / Folder) を優先し、
  キャッシュより先にサブタイプを参照する。
- target=both は引き続き常に true (種別関係なくマッチ)。

### #30: rename → Rename イベント
- notify はリネームを \`EventKind::Modify(ModifyKind::Name(_))\` として通知するが、
  これまで Modify として処理されていた。\`ModifyKind::Name(_)\` を
  \`Event::Rename\` にマッピングする分岐を追加。
- (この修正は元 PR #31 として PR #29 にマージ済みだが、main には未到達のため
  本 PR に取り込む)

### Linux クロスコンパイル対応
- \`cat-watcher/build.rs\` に mingw の \`windres\` / \`ar\` を自動利用する分岐を追加し、
  x86_64-pc-windows-gnu ターゲットへのクロスコンパイルが Linux でも通るようにする。

## 含まれるコミット

- \`fix: Delete イベント時のファイル/ディレクトリ種別判定を修正\`
- \`fix: target=file が Delete 単体で検知しないバグを修正 (Windows)\` (Closes #23)
- \`test: #23/#24 の回帰テストを追加 + build.rs に Linux クロスコンパイル対応\`
- \`fix: rename を Modify ではなく Rename イベントとして検知 (#30)\`

## Test plan

- [x] \`cargo test --package cat-watcher\` で 128 件パス (回帰なし)
- [x] Win11 ローカル C: ドライブで \`Run-CatWatcherTest.ps1\` 実機検証
  - ファイル削除: \`Delete\` として検知 ✅
  - フォルダ削除: \`Delete\` として検知 ✅
  - サブフォルダ削除 (recursive): 内側ファイルも親フォルダも検知 ✅
  - rename: 旧名/新名それぞれ \`Rename\` として検知 ✅
  - Create / Modify: 回帰なし

## 関連

PR #29 を 3 つに分割した 2つ目。base は PR #33 (notify-fork RDExW) マージ済みの main。

Closes #23
Closes #24
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>