### PR TITLE
feat: ログ機能拡充 (4列フォーマット / 個別レベル / ルール別ログ) (#20 #22 #25 #27)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.8.23",
+ "unicode-width",
  "walkdir",
  "winres",
 ]
@@ -460,7 +461,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1078,6 +1079,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,7 +1230,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
- "windows-core 0.56.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -1233,23 +1240,10 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-implement 0.56.0",
- "windows-interface 0.56.0",
- "windows-result 0.1.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -1264,32 +1258,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1309,24 +1281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1.51.1", features = ["rt-multi-thread", "macros", "sync", "
 blake3 = "1"
 walkdir = "2"
 colored = "2"
+unicode-width = "0.2"
 
 [build-dependencies]
 winres = "0.1"

--- a/cat-watcher/src/actions/command.rs
+++ b/cat-watcher/src/actions/command.rs
@@ -90,6 +90,8 @@ mod tests {
             retry_interval_ms: 0,
             log_to_console: false,
             log_to_file: false,
+            terminal_log_level: None,
+            file_log_level: None,
         }
     }
 
@@ -124,6 +126,8 @@ mod tests {
             retry_interval_ms: 0,
             log_to_console: false,
             log_to_file: false,
+            terminal_log_level: None,
+            file_log_level: None,
         };
         std::mem::forget(dir);
         let (logger, _) = Logger::new(&global).unwrap();

--- a/cat-watcher/src/actions/command.rs
+++ b/cat-watcher/src/actions/command.rs
@@ -12,6 +12,7 @@ pub async fn execute(
     ctx: &PlaceholderContext,
     _global: &Global,
     log: Arc<Logger>,
+    step: (usize, usize),
 ) -> Result<(), AppError> {
     let raw_command = action
         .command
@@ -42,7 +43,7 @@ pub async fn execute(
         ))
     })?;
 
-    log.info(format!("コマンド起動: shell={shell} cmd={expanded}"));
+    log.log_action_ok(step.0, step.1, "起動");
     Ok(())
 }
 
@@ -87,6 +88,8 @@ mod tests {
             log_rotation: LogRotation::Never,
             retry_count: 0,
             retry_interval_ms: 0,
+            log_to_console: false,
+            log_to_file: false,
         }
     }
 
@@ -119,6 +122,8 @@ mod tests {
             log_rotation: LogRotation::Never,
             retry_count: 0,
             retry_interval_ms: 0,
+            log_to_console: false,
+            log_to_file: false,
         };
         std::mem::forget(dir);
         let (logger, _) = Logger::new(&global).unwrap();
@@ -133,7 +138,7 @@ mod tests {
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("bash", "echo hi", "");
         let global = make_global();
-        let result = execute(&action, &ctx, &global, make_logger()).await;
+        let result = execute(&action, &ctx, &global, make_logger(), (1, 1)).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("不明なシェル"));
     }
@@ -147,7 +152,7 @@ mod tests {
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd", "echo hello", "");
         let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger()).await.is_ok());
+        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -159,7 +164,7 @@ mod tests {
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd", "echo {Name}", "");
         let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger()).await.is_ok());
+        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -171,7 +176,7 @@ mod tests {
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd", "echo hi", dir.path().to_str().unwrap());
         let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger()).await.is_ok());
+        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
     }
 
     #[test]

--- a/cat-watcher/src/actions/copy.rs
+++ b/cat-watcher/src/actions/copy.rs
@@ -177,6 +177,8 @@ mod tests {
             retry_interval_ms: 10,
             log_to_console: false,
             log_to_file: false,
+            terminal_log_level: None,
+            file_log_level: None,
         }
     }
 
@@ -220,6 +222,8 @@ mod tests {
             retry_interval_ms: 0,
             log_to_console: false,
             log_to_file: false,
+            terminal_log_level: None,
+            file_log_level: None,
         };
         std::mem::forget(dir);
         let (logger, _) = Logger::new(&global).unwrap();

--- a/cat-watcher/src/actions/copy.rs
+++ b/cat-watcher/src/actions/copy.rs
@@ -22,6 +22,7 @@ pub async fn execute(
     ctx: &PlaceholderContext,
     global: &Global,
     log: Arc<Logger>,
+    step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     let dest_root = expand_action_destination(action, ctx)?;
 
@@ -40,11 +41,12 @@ pub async fn execute(
             verify_integrity,
             global,
             log,
+            step,
         )
         .await
     } else {
         let dest_file = resolve_dest_path(src, &dest_root, watch_path, preserve_structure)?;
-        copy_one_file(src, &dest_file, overwrite, verify_integrity, global, log).await
+        copy_one_file(src, &dest_file, overwrite, verify_integrity, global, log, step).await
     }
 }
 
@@ -56,6 +58,7 @@ async fn copy_one_file(
     verify_integrity: bool,
     global: &Global,
     log: Arc<Logger>,
+    step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     if dest.exists() && !overwrite {
         log.warn(format!(
@@ -84,7 +87,10 @@ async fn copy_one_file(
                 let hash_suffix = maybe_hash
                     .map(|h| format!("  [BLAKE3: {h}]"))
                     .unwrap_or_default();
-                log.success(format!("コピー完了: {} → {}{}", src.display(), dest.display(), hash_suffix));
+                log.log_action_ok(step.0, step.1, format!(
+                    "コピー完了: {} → {}{}",
+                    src.display(), dest.display(), hash_suffix
+                ));
                 return Ok(Some(dest.to_path_buf()));
             }
             Err(e) => {
@@ -118,6 +124,7 @@ async fn copy_directory_recursive(
     verify_integrity: bool,
     global: &Global,
     log: Arc<Logger>,
+    step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     let folder_dest = if preserve_structure {
         let rel = src_dir
@@ -146,7 +153,7 @@ async fn copy_directory_recursive(
             .strip_prefix(src_dir)
             .map_err(|e| AppError::Action(format!("配下相対パス解決失敗: {}", e)))?;
         let entry_dest = folder_dest.join(rel);
-        copy_one_file(&entry, &entry_dest, overwrite, verify_integrity, global, Arc::clone(&log)).await?;
+        copy_one_file(&entry, &entry_dest, overwrite, verify_integrity, global, Arc::clone(&log), step).await?;
     }
 
     Ok(Some(folder_dest))
@@ -168,6 +175,8 @@ mod tests {
             log_rotation: LogRotation::Never,
             retry_count,
             retry_interval_ms: 10,
+            log_to_console: false,
+            log_to_file: false,
         }
     }
 
@@ -209,6 +218,8 @@ mod tests {
             log_rotation: LogRotation::Never,
             retry_count: 0,
             retry_interval_ms: 0,
+            log_to_console: false,
+            log_to_file: false,
         };
         std::mem::forget(dir);
         let (logger, _) = Logger::new(&global).unwrap();
@@ -226,7 +237,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         let dest_file = dest.path().join("a.txt");
         assert!(dest_file.exists());
         assert_eq!(result, Some(dest_file));
@@ -243,7 +254,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert!(dest.path().join("sub/deep/a.txt").exists());
     }
 
@@ -260,7 +271,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert_eq!(result, None);
         assert_eq!(std::fs::read(&dest_file).unwrap(), b"old");
     }
@@ -278,7 +289,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert_eq!(std::fs::read(&dest_file).unwrap(), b"new");
     }
 
@@ -293,7 +304,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert!(result.is_some());
         assert!(dest.path().join("a.txt").exists());
     }
@@ -310,7 +321,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src_dir, watch.path(), "");
 
-        let result = execute(&action, &src_dir, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src_dir, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert_eq!(result, Some(dest.path().join("mydir")));
         assert!(dest.path().join("mydir/a.txt").exists());
         assert!(dest.path().join("mydir/sub/b.txt").exists());
@@ -331,7 +342,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         let dest_path = result.expect("コピー成功");
 
         assert!(dest_path.exists(), "コピー先ファイルが存在しない: {}", dest_path.display());
@@ -356,7 +367,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         let expected = dest.path().join("a").join("a.txt");
         assert_eq!(result.as_deref(), Some(expected.as_path()));
         assert!(expected.exists());

--- a/cat-watcher/src/actions/execute.rs
+++ b/cat-watcher/src/actions/execute.rs
@@ -70,6 +70,8 @@ mod tests {
             retry_interval_ms: 0,
             log_to_console: false,
             log_to_file: false,
+            terminal_log_level: None,
+            file_log_level: None,
         }
     }
 
@@ -104,6 +106,8 @@ mod tests {
             retry_interval_ms: 0,
             log_to_console: false,
             log_to_file: false,
+            terminal_log_level: None,
+            file_log_level: None,
         };
         std::mem::forget(dir);
         let (logger, _) = Logger::new(&global).unwrap();

--- a/cat-watcher/src/actions/execute.rs
+++ b/cat-watcher/src/actions/execute.rs
@@ -12,6 +12,7 @@ pub async fn execute(
     ctx: &PlaceholderContext,
     _global: &Global,
     log: Arc<Logger>,
+    step: (usize, usize),
 ) -> Result<(), AppError> {
     let program = action
         .program
@@ -48,7 +49,7 @@ pub async fn execute(
         ))
     })?;
 
-    log.info(format!("プロセス起動: program={program} args={expanded_args:?}"));
+    log.log_action_ok(step.0, step.1, "起動");
     Ok(())
 }
 
@@ -67,6 +68,8 @@ mod tests {
             log_rotation: LogRotation::Never,
             retry_count: 0,
             retry_interval_ms: 0,
+            log_to_console: false,
+            log_to_file: false,
         }
     }
 
@@ -99,6 +102,8 @@ mod tests {
             log_rotation: LogRotation::Never,
             retry_count: 0,
             retry_interval_ms: 0,
+            log_to_console: false,
+            log_to_file: false,
         };
         std::mem::forget(dir);
         let (logger, _) = Logger::new(&global).unwrap();
@@ -114,7 +119,7 @@ mod tests {
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd.exe", vec!["/C", "echo hello"], "");
         let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger()).await.is_ok());
+        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -126,7 +131,7 @@ mod tests {
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd.exe", vec!["/C", "echo {FullName}"], "");
         let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger()).await.is_ok());
+        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -138,7 +143,7 @@ mod tests {
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd.exe", vec!["/C", "echo hi"], dir.path().to_str().unwrap());
         let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger()).await.is_ok());
+        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
     }
 
     #[tokio::test]
@@ -149,7 +154,7 @@ mod tests {
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("nonexistent_program_xyz.exe", vec![], "");
         let global = make_global();
-        let result = execute(&action, &ctx, &global, make_logger()).await;
+        let result = execute(&action, &ctx, &global, make_logger(), (1, 1)).await;
         assert!(result.is_err());
     }
 }

--- a/cat-watcher/src/actions/mod.rs
+++ b/cat-watcher/src/actions/mod.rs
@@ -26,11 +26,12 @@ pub async fn execute_chain(
 
     for (i, action) in actions.iter().enumerate() {
         let index = i + 1;
+        let step = (index, total);
         match action.type_ {
             ActionType::Copy => {
                 let dest_str = action.destination.as_deref().unwrap_or("");
                 log.log_action(index, total, "copy", format!("{} → {}", src.display(), dest_str));
-                let result = copy::execute(action, src, &ctx, global, Arc::clone(&log)).await?;
+                let result = copy::execute(action, src, &ctx, global, Arc::clone(&log), step).await?;
                 if let Some(dest_file) = result {
                     ctx.destination = dest_file.to_string_lossy().replace('\\', "/");
                 }
@@ -38,7 +39,7 @@ pub async fn execute_chain(
             ActionType::Move => {
                 let dest_str = action.destination.as_deref().unwrap_or("");
                 log.log_action(index, total, "move", format!("{} → {}", src.display(), dest_str));
-                let result = r#move::execute(action, src, &ctx, global, Arc::clone(&log)).await?;
+                let result = r#move::execute(action, src, &ctx, global, Arc::clone(&log), step).await?;
                 if let Some(dest_file) = result {
                     ctx.destination = dest_file.to_string_lossy().replace('\\', "/");
                 }
@@ -47,18 +48,20 @@ pub async fn execute_chain(
                 let shell = action.shell.as_deref().unwrap_or("");
                 let cmd = action.command.as_deref().unwrap_or("");
                 log.log_action(index, total, "command", format!("shell={shell}  cmd={cmd}"));
-                command::execute(action, &ctx, global, Arc::clone(&log)).await?;
+                command::execute(action, &ctx, global, Arc::clone(&log), step).await?;
             }
             ActionType::Execute => {
                 let program = action.program.as_deref().unwrap_or("");
-                log.log_action(index, total, "execute", format!("program={program}"));
-                execute::execute(action, &ctx, global, Arc::clone(&log)).await?;
+                let args = action.args.as_deref().unwrap_or(&[]);
+                let args_str = args.join(" ");
+                log.log_action(index, total, "execute", format!("{program} {args_str}").trim_end().to_string());
+                execute::execute(action, &ctx, global, Arc::clone(&log), step).await?;
             }
             ActionType::Log => {
                 let raw = action.message.as_deref().unwrap_or("");
                 let msg = expand_placeholders(raw, &ctx)?;
                 log.log_action(index, total, "log", "");
-                log.info(msg);
+                log.log_action_ok(index, total, msg);
             }
         }
     }

--- a/cat-watcher/src/actions/mod.rs
+++ b/cat-watcher/src/actions/mod.rs
@@ -12,6 +12,16 @@ use crate::error::AppError;
 use crate::logger::Logger;
 use crate::placeholder::{expand_placeholders, PlaceholderContext};
 
+/// global ロガーとルール別ロガーの両方に同じエントリを送る。
+macro_rules! log_all {
+    ($log:expr, $rule_log:expr, $method:ident ( $($arg:expr),* )) => {{
+        $log.$method($($arg.clone()),*);
+        if let Some(rl) = $rule_log {
+            rl.$method($($arg),*);
+        }
+    }};
+}
+
 /// 1 つの監視イベントに対して、ルールの actions を順に実行する。
 /// アクション間で PlaceholderContext を保持し、copy/move 完了後に {Destination} を更新する。
 pub async fn execute_chain(
@@ -20,6 +30,7 @@ pub async fn execute_chain(
     watch_path: &Path,
     global: &Global,
     log: Arc<Logger>,
+    rule_log: Option<Arc<Logger>>,
 ) -> Result<(), AppError> {
     let mut ctx = PlaceholderContext::new(src, watch_path, "");
     let total = actions.len();
@@ -30,7 +41,8 @@ pub async fn execute_chain(
         match action.type_ {
             ActionType::Copy => {
                 let dest_str = action.destination.as_deref().unwrap_or("");
-                log.log_action(index, total, "copy", format!("{} → {}", src.display(), dest_str));
+                let detail = format!("{} → {}", src.display(), dest_str);
+                log_all!(log, rule_log.as_deref(), log_action(index, total, "copy", detail));
                 let result = copy::execute(action, src, &ctx, global, Arc::clone(&log), step).await?;
                 if let Some(dest_file) = result {
                     ctx.destination = dest_file.to_string_lossy().replace('\\', "/");
@@ -38,7 +50,8 @@ pub async fn execute_chain(
             }
             ActionType::Move => {
                 let dest_str = action.destination.as_deref().unwrap_or("");
-                log.log_action(index, total, "move", format!("{} → {}", src.display(), dest_str));
+                let detail = format!("{} → {}", src.display(), dest_str);
+                log_all!(log, rule_log.as_deref(), log_action(index, total, "move", detail));
                 let result = r#move::execute(action, src, &ctx, global, Arc::clone(&log), step).await?;
                 if let Some(dest_file) = result {
                     ctx.destination = dest_file.to_string_lossy().replace('\\', "/");
@@ -47,21 +60,23 @@ pub async fn execute_chain(
             ActionType::Command => {
                 let shell = action.shell.as_deref().unwrap_or("");
                 let cmd = action.command.as_deref().unwrap_or("");
-                log.log_action(index, total, "command", format!("shell={shell}  cmd={cmd}"));
+                let detail = format!("shell={shell}  cmd={cmd}");
+                log_all!(log, rule_log.as_deref(), log_action(index, total, "command", detail));
                 command::execute(action, &ctx, global, Arc::clone(&log), step).await?;
             }
             ActionType::Execute => {
                 let program = action.program.as_deref().unwrap_or("");
                 let args = action.args.as_deref().unwrap_or(&[]);
                 let args_str = args.join(" ");
-                log.log_action(index, total, "execute", format!("{program} {args_str}").trim_end().to_string());
+                let detail = format!("{program} {args_str}").trim_end().to_string();
+                log_all!(log, rule_log.as_deref(), log_action(index, total, "execute", detail));
                 execute::execute(action, &ctx, global, Arc::clone(&log), step).await?;
             }
             ActionType::Log => {
                 let raw = action.message.as_deref().unwrap_or("");
                 let msg = expand_placeholders(raw, &ctx)?;
-                log.log_action(index, total, "log", "");
-                log.log_action_ok(index, total, msg);
+                log_all!(log, rule_log.as_deref(), log_action(index, total, "log", ""));
+                log_all!(log, rule_log.as_deref(), log_action_ok(index, total, msg));
             }
         }
     }

--- a/cat-watcher/src/actions/move.rs
+++ b/cat-watcher/src/actions/move.rs
@@ -23,6 +23,7 @@ pub async fn execute(
     ctx: &PlaceholderContext,
     global: &Global,
     log: Arc<Logger>,
+    step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     let dest_root = expand_action_destination(action, ctx)?;
 
@@ -41,11 +42,12 @@ pub async fn execute(
             verify_integrity,
             global,
             log,
+            step,
         )
         .await
     } else {
         let dest_file = resolve_dest_path(src, &dest_root, watch_path, preserve_structure)?;
-        move_one_file(src, &dest_file, overwrite, verify_integrity, global, log).await
+        move_one_file(src, &dest_file, overwrite, verify_integrity, global, log, step).await
     }
 }
 
@@ -57,6 +59,7 @@ async fn move_one_file(
     verify_integrity: bool,
     global: &Global,
     log: Arc<Logger>,
+    step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     if dest.exists() && !overwrite {
         log.warn(format!(
@@ -79,7 +82,7 @@ async fn move_one_file(
     // まず rename を試みる（同一ボリューム）
     match tokio::fs::rename(src, dest).await {
         Ok(()) => {
-            log.success(format!("移動完了 (rename): {} → {}", src.display(), dest.display()));
+            log.log_action_ok(step.0, step.1, format!("移動完了 (rename): {} → {}", src.display(), dest.display()));
             return Ok(Some(dest.to_path_buf()));
         }
         Err(e) if is_cross_device(&e) => {
@@ -115,7 +118,7 @@ async fn move_one_file(
                 let hash_suffix = maybe_hash
                     .map(|h| format!("  [BLAKE3: {h}]"))
                     .unwrap_or_default();
-                log.success(format!(
+                log.log_action_ok(step.0, step.1, format!(
                     "移動完了 (copy+delete): {} → {}{}",
                     src.display(),
                     dest.display(),
@@ -154,6 +157,7 @@ async fn move_directory_recursive(
     verify_integrity: bool,
     global: &Global,
     log: Arc<Logger>,
+    step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     let folder_dest = if preserve_structure {
         let rel = src_dir
@@ -182,7 +186,7 @@ async fn move_directory_recursive(
             .strip_prefix(src_dir)
             .map_err(|e| AppError::Action(format!("配下相対パス解決失敗: {}", e)))?;
         let entry_dest = folder_dest.join(rel);
-        move_one_file(entry, &entry_dest, overwrite, verify_integrity, global, Arc::clone(&log)).await?;
+        move_one_file(entry, &entry_dest, overwrite, verify_integrity, global, Arc::clone(&log), step).await?;
     }
 
     tokio::fs::remove_dir_all(src_dir).await.map_err(|e| {
@@ -233,6 +237,8 @@ mod tests {
             log_rotation: LogRotation::Never,
             retry_count,
             retry_interval_ms: 10,
+            log_to_console: false,
+            log_to_file: false,
         }
     }
 
@@ -273,6 +279,8 @@ mod tests {
             log_rotation: LogRotation::Never,
             retry_count: 0,
             retry_interval_ms: 0,
+            log_to_console: false,
+            log_to_file: false,
         };
         std::mem::forget(dir);
         let (logger, _) = Logger::new(&global).unwrap();
@@ -290,7 +298,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert_eq!(result, Some(dest.path().join("a.txt")));
         assert!(dest.path().join("a.txt").exists());
         assert!(!src.exists(), "元ファイルが残っている");
@@ -308,7 +316,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert_eq!(result, None);
         assert_eq!(std::fs::read(dest.path().join("a.txt")).unwrap(), b"old");
         assert!(src.exists(), "スキップ時は元ファイルを保持");
@@ -326,7 +334,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert_eq!(std::fs::read(dest.path().join("a.txt")).unwrap(), b"new");
         assert!(!src.exists());
     }
@@ -342,7 +350,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert!(dest.path().join("sub/deep/a.txt").exists());
         assert!(!src.exists());
     }
@@ -359,7 +367,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src_dir, watch.path(), "");
 
-        let result = execute(&action, &src_dir, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src_dir, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert_eq!(result, Some(dest.path().join("mydir")));
         assert!(dest.path().join("mydir/a.txt").exists());
         assert!(dest.path().join("mydir/sub/b.txt").exists());
@@ -377,7 +385,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         assert!(result.is_some());
         assert!(!src.exists());
     }
@@ -397,7 +405,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await.unwrap();
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
         let dest_path = result.expect("移動成功");
         assert!(dest_path.exists());
         assert_eq!(dest_path.file_name().unwrap(), "a.txt");
@@ -414,7 +422,7 @@ mod tests {
         let global = make_global(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger()).await;
+        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await;
         assert!(result.is_err(), "存在しないファイルの move はエラー");
     }
 

--- a/cat-watcher/src/actions/move.rs
+++ b/cat-watcher/src/actions/move.rs
@@ -239,6 +239,8 @@ mod tests {
             retry_interval_ms: 10,
             log_to_console: false,
             log_to_file: false,
+            terminal_log_level: None,
+            file_log_level: None,
         }
     }
 
@@ -281,6 +283,8 @@ mod tests {
             retry_interval_ms: 0,
             log_to_console: false,
             log_to_file: false,
+            terminal_log_level: None,
+            file_log_level: None,
         };
         std::mem::forget(dir);
         let (logger, _) = Logger::new(&global).unwrap();

--- a/cat-watcher/src/config.rs
+++ b/cat-watcher/src/config.rs
@@ -103,6 +103,10 @@ pub struct RulesConfig {
     pub rules: Vec<Rule>,
 }
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Global {
     pub log_level: LogLevel,
@@ -111,6 +115,10 @@ pub struct Global {
     pub log_rotation: LogRotation,
     pub retry_count: u32,
     pub retry_interval_ms: u64,
+    #[serde(default = "default_true")]
+    pub log_to_console: bool,
+    #[serde(default = "default_true")]
+    pub log_to_file: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -563,6 +571,8 @@ mod tests {
 				log_rotation: LogRotation::Daily,
 				retry_count: 3,
 				retry_interval_ms: 1000,
+				log_to_console: true,
+				log_to_file: true,
 			},
 		};
 		let result = validate_global_config(&config);
@@ -579,6 +589,8 @@ mod tests {
 				log_rotation: LogRotation::Daily,
 				retry_count: 3,
 				retry_interval_ms: 1000,
+				log_to_console: true,
+				log_to_file: true,
 			},
 		};
 		let result = validate_global_config(&config);
@@ -596,6 +608,8 @@ mod tests {
 				log_rotation: LogRotation::Daily,
 				retry_count: 3,
 				retry_interval_ms: 1000,
+				log_to_console: true,
+				log_to_file: true,
 			},
 		};
 		let result = validate_global_config(&config);
@@ -613,6 +627,8 @@ mod tests {
 				log_rotation: LogRotation::Daily,
 				retry_count: 3,
 				retry_interval_ms: 1000,
+				log_to_console: true,
+				log_to_file: true,
 			},
 		};
 		let result = validate_global_config(&config);
@@ -630,6 +646,8 @@ mod tests {
 				log_rotation: LogRotation::Daily,
 				retry_count: 3,
 				retry_interval_ms: 1000,
+				log_to_console: true,
+				log_to_file: true,
 			},
 		};
 		let result = validate_global_config(&config);

--- a/cat-watcher/src/config.rs
+++ b/cat-watcher/src/config.rs
@@ -119,6 +119,19 @@ pub struct Global {
     pub log_to_console: bool,
     #[serde(default = "default_true")]
     pub log_to_file: bool,
+    /// ターミナル出力専用ログレベル。省略時は log_level を使用。
+    pub terminal_log_level: Option<LogLevel>,
+    /// ファイル出力専用ログレベル。省略時は log_level を使用。
+    pub file_log_level: Option<LogLevel>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RuleLog {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    pub log_dir: Option<String>,
+    pub log_file_name: Option<String>,
+    pub log_rotation: Option<LogRotation>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -127,6 +140,7 @@ pub struct Rule {
     pub name: String,
     pub watch: Watch,
     pub actions: Vec<ActionConfig>,
+    pub log: Option<RuleLog>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -285,6 +299,36 @@ pub fn validate_rules_config(config: &RulesConfig) -> Result<(), AppError> {
 		for glob in &rule.watch.exclude_patterns {
 			if let Err(e) = Glob::new(glob) {
 				errors.push(format!("監視ルール名 {} の exclude_patterns に無効な glob があります '{}': {}", rule_id, glob, e));
+			}
+		}
+
+		if let Some(rule_log) = &rule.log {
+			if rule_log.enabled {
+				if let Some(dir) = &rule_log.log_dir {
+					let p = Path::new(dir);
+					if !p.exists() {
+						errors.push(format!("監視ルール名 {} の log.log_dir が存在しません: {}", rule_id, dir));
+					} else if !p.is_dir() {
+						errors.push(format!("監視ルール名 {} の log.log_dir にディレクトリ以外のパスが指定されています: {}", rule_id, dir));
+					}
+				}
+				if let Some(file_name) = &rule_log.log_file_name {
+					if file_name.trim().is_empty() {
+						errors.push(format!("監視ルール名 {} の log.log_file_name が空文字列です", rule_id));
+					} else {
+						let valid_placeholders = ["Date", "DateTime"];
+						let re = regex::Regex::new(r"\{([A-Za-z]+)\}").unwrap();
+						for caps in re.captures_iter(file_name) {
+							let name = &caps[1];
+							if !valid_placeholders.contains(&name) {
+								errors.push(format!(
+									"監視ルール名 {} の log.log_file_name に使用できないプレースホルダーがあります: {{{name}}}",
+									rule_id
+								));
+							}
+						}
+					}
+				}
 			}
 		}
 	}
@@ -573,6 +617,8 @@ mod tests {
 				retry_interval_ms: 1000,
 				log_to_console: true,
 				log_to_file: true,
+				terminal_log_level: None,
+				file_log_level: None,
 			},
 		};
 		let result = validate_global_config(&config);
@@ -591,6 +637,8 @@ mod tests {
 				retry_interval_ms: 1000,
 				log_to_console: true,
 				log_to_file: true,
+				terminal_log_level: None,
+				file_log_level: None,
 			},
 		};
 		let result = validate_global_config(&config);
@@ -610,6 +658,8 @@ mod tests {
 				retry_interval_ms: 1000,
 				log_to_console: true,
 				log_to_file: true,
+				terminal_log_level: None,
+				file_log_level: None,
 			},
 		};
 		let result = validate_global_config(&config);
@@ -629,6 +679,8 @@ mod tests {
 				retry_interval_ms: 1000,
 				log_to_console: true,
 				log_to_file: true,
+				terminal_log_level: None,
+				file_log_level: None,
 			},
 		};
 		let result = validate_global_config(&config);
@@ -648,6 +700,8 @@ mod tests {
 				retry_interval_ms: 1000,
 				log_to_console: true,
 				log_to_file: true,
+				terminal_log_level: None,
+				file_log_level: None,
 			},
 		};
 		let result = validate_global_config(&config);

--- a/cat-watcher/src/logger.rs
+++ b/cat-watcher/src/logger.rs
@@ -9,11 +9,30 @@ use tokio::sync::mpsc;
 
 use crate::config::{Global, LogLevel, LogRotation};
 use crate::error::AppError;
+use unicode_width::UnicodeWidthStr;
 
 const SEPARATOR: &str = "──────────────────────────────────────────────────────────────";
 
 const FILE_LEVEL_WIDTH: usize = 7;
 const FILE_EVENTS_WIDTH: usize = 27;
+
+/// 表示列幅 (East Asian Width, CJK モード) で左寄せパディングする。
+/// Rust 標準の `format!("{:<width$}")` は char 数で揃えるため、
+/// '└' '│' '├' '─' などの罫線記号で表示時に列幅がズレる。
+/// 本プロジェクトは日本語ロケール (CJK) を主用途とするため、
+/// East Asian Ambiguous 文字を 2 列幅として扱う `width_cjk()` を使う。
+fn pad_left_display(s: &str, total_cols: usize) -> String {
+    let w = UnicodeWidthStr::width_cjk(s);
+    if w >= total_cols {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + (total_cols - w));
+    out.push_str(s);
+    for _ in 0..(total_cols - w) {
+        out.push(' ');
+    }
+    out
+}
 
 #[derive(Debug)]
 pub enum LogEntry {
@@ -191,44 +210,54 @@ fn action_type_short(action_type: &str) -> &str {
     }
 }
 
-/// ファイルログ用 level カラム文字列（FILE_LEVEL_WIDTH 幅）を生成する。
+/// ファイルログ用 level カラム文字列（FILE_LEVEL_WIDTH **列** 幅）を生成する。
+/// 全角記号 ('└' '├' '│') を含むため、char 数ではなく表示列幅でパディングする。
 fn file_level_col(entry: &LogEntry) -> String {
     match entry {
-        LogEntry::Match { .. } => format!("{:<width$}", "MATCH", width = FILE_LEVEL_WIDTH),
+        LogEntry::Match { .. } => pad_left_display("MATCH", FILE_LEVEL_WIDTH),
         LogEntry::Action { index, total, action_type, .. } => {
             let tree = if *index == *total { '└' } else { '├' };
             let short = action_type_short(action_type);
             let index_str = index.to_string();
-            let index_len = index_str.len();
-            // tree(1) + index + space(1) + type; truncate type to fit in FILE_LEVEL_WIDTH
-            let type_max = FILE_LEVEL_WIDTH.saturating_sub(1 + index_len + 1);
-            let type_part: String = short.chars().take(type_max).collect();
-            format!("{:<width$}", format!("{}{} {}", tree, index_str, type_part), width = FILE_LEVEL_WIDTH)
+            // tree ('└'/'├' は CJK で 列幅 2) + index + space(1) + type で
+            // FILE_LEVEL_WIDTH 列に収める。type も CJK 列幅基準で切り詰める。
+            let used_cols = 2 + index_str.len() + 1;
+            let type_max_cols = FILE_LEVEL_WIDTH.saturating_sub(used_cols);
+            let mut type_part = String::new();
+            let mut used = 0usize;
+            for c in short.chars() {
+                let cw = UnicodeWidthStr::width_cjk(c.to_string().as_str());
+                if used + cw > type_max_cols { break; }
+                type_part.push(c);
+                used += cw;
+            }
+            let head = format!("{}{} {}", tree, index_str, type_part);
+            pad_left_display(&head, FILE_LEVEL_WIDTH)
         }
         LogEntry::ActionOk { index, total, .. } => {
             if *index == *total {
                 // 最終ステップ完了: 継続パイプなし
-                format!("{:<width$}", "   OK", width = FILE_LEVEL_WIDTH)
+                pad_left_display("   OK", FILE_LEVEL_WIDTH)
             } else {
-                // 中間ステップ完了: 継続パイプあり
-                format!("{:<width$}", "│   OK", width = FILE_LEVEL_WIDTH)
+                // 中間ステップ完了: 継続パイプあり ('│' は列幅 2)
+                pad_left_display("│   OK", FILE_LEVEL_WIDTH)
             }
         }
-        LogEntry::Info(_) => format!("{:<width$}", "INFO", width = FILE_LEVEL_WIDTH),
-        LogEntry::Warn(_) => format!("{:<width$}", "WARN", width = FILE_LEVEL_WIDTH),
-        LogEntry::Error(_) => format!("{:<width$}", "ERROR", width = FILE_LEVEL_WIDTH),
+        LogEntry::Info(_) => pad_left_display("INFO", FILE_LEVEL_WIDTH),
+        LogEntry::Warn(_) => pad_left_display("WARN", FILE_LEVEL_WIDTH),
+        LogEntry::Error(_) => pad_left_display("ERROR", FILE_LEVEL_WIDTH),
         LogEntry::Shutdown => unreachable!(),
     }
 }
 
-/// ファイルログ用 events カラム文字列（FILE_EVENTS_WIDTH 幅）を生成する。
+/// ファイルログ用 events カラム文字列（FILE_EVENTS_WIDTH **列** 幅）を生成する。
 /// MATCH エントリのみイベント名を出力し、それ以外は空白で埋める。
 fn file_events_col(entry: &LogEntry) -> String {
     let s = match entry {
         LogEntry::Match { events, .. } => format_events(events),
         _ => String::new(),
     };
-    format!("{:<width$}", s, width = FILE_EVENTS_WIDTH)
+    pad_left_display(&s, FILE_EVENTS_WIDTH)
 }
 
 /// ファイルログ用 content カラムを生成する。
@@ -417,4 +446,51 @@ fn format_events(events: &HashSet<crate::config::Event>) -> String {
         .collect();
     names.sort();
     names.join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 罫線文字 ('└') は East Asian Ambiguous で、CJK モードでは 2 列幅。
+    /// "└1 log" は 2+1+1+1+1+1 = 7 列、ピッタリ収まる。
+    #[test]
+    fn test_pad_left_display_with_eaw_chars() {
+        let s = pad_left_display("└1 log", 7);
+        assert_eq!(UnicodeWidthStr::width_cjk(s.as_str()), 7);
+        assert_eq!(s, "└1 log"); // 既に 7 列なので追加スペースなし
+    }
+
+    /// ASCII のみの文字列は char 数と CJK 列幅が一致する
+    #[test]
+    fn test_pad_left_display_ascii() {
+        let s = pad_left_display("MATCH", 7);
+        assert_eq!(s, "MATCH  ");
+        assert_eq!(UnicodeWidthStr::width_cjk(s.as_str()), 7);
+    }
+
+    /// '│' は CJK で 2 列幅。"│   OK" は 2+3+2 = 7 列。
+    #[test]
+    fn test_pad_left_display_middle_action_ok() {
+        let s = pad_left_display("│   OK", 7);
+        assert_eq!(UnicodeWidthStr::width_cjk(s.as_str()), 7);
+    }
+
+    /// 列幅オーバーは切り詰めず返す (元の動作維持)
+    #[test]
+    fn test_pad_left_display_overflow() {
+        let s = pad_left_display("VERYLONGTEXT", 5);
+        assert_eq!(s, "VERYLONGTEXT");
+    }
+
+    /// 罫線なしのレベル文字列が CJK 列幅 7 列で揃う
+    #[test]
+    fn test_pad_left_display_info_aligns_with_match() {
+        let info = pad_left_display("INFO", FILE_LEVEL_WIDTH);
+        let match_ = pad_left_display("MATCH", FILE_LEVEL_WIDTH);
+        let action_ok = pad_left_display("│   OK", FILE_LEVEL_WIDTH);
+        assert_eq!(UnicodeWidthStr::width_cjk(info.as_str()), FILE_LEVEL_WIDTH);
+        assert_eq!(UnicodeWidthStr::width_cjk(match_.as_str()), FILE_LEVEL_WIDTH);
+        assert_eq!(UnicodeWidthStr::width_cjk(action_ok.as_str()), FILE_LEVEL_WIDTH);
+    }
 }

--- a/cat-watcher/src/logger.rs
+++ b/cat-watcher/src/logger.rs
@@ -12,23 +12,30 @@ use crate::error::AppError;
 
 const SEPARATOR: &str = "──────────────────────────────────────────────────────────────";
 
+const FILE_LEVEL_WIDTH: usize = 7;
+const FILE_EVENTS_WIDTH: usize = 27;
+
 #[derive(Debug)]
 pub enum LogEntry {
-    /// イベントブロック開始（セパレーター + MATCHラベル）
+    /// イベントブロック開始
     Match {
         rule_name: String,
         path: String,
         events: HashSet<crate::config::Event>,
     },
-    /// アクション開始
+    /// アクションチェーン ステップ開始
     Action {
         index: usize,
         total: usize,
         action_type: String,
         detail: String,
     },
-    /// アクション正常完了
-    Success(String),
+    /// アクションチェーン ステップ完了
+    ActionOk {
+        index: usize,
+        total: usize,
+        msg: String,
+    },
     /// 通常情報
     Info(String),
     /// 警告
@@ -53,8 +60,18 @@ impl Logger {
         let log_dir = global.log_dir.clone();
         let log_file_name = global.log_file_name.clone();
         let log_rotation = global.log_rotation.clone();
+        let log_to_console = global.log_to_console;
+        let log_to_file = global.log_to_file;
         let (tx, rx) = mpsc::unbounded_channel();
-        let handle = tokio::spawn(writer_task(rx, log_dir, log_file_name, level, log_rotation));
+        let handle = tokio::spawn(writer_task(
+            rx,
+            log_dir,
+            log_file_name,
+            level,
+            log_rotation,
+            log_to_console,
+            log_to_file,
+        ));
         Ok((Self { tx }, handle))
     }
 
@@ -86,12 +103,16 @@ impl Logger {
         });
     }
 
-    pub fn info(&self, msg: impl Into<String>) {
-        let _ = self.tx.send(LogEntry::Info(msg.into()));
+    pub fn log_action_ok(&self, index: usize, total: usize, msg: impl Into<String>) {
+        let _ = self.tx.send(LogEntry::ActionOk {
+            index,
+            total,
+            msg: msg.into(),
+        });
     }
 
-    pub fn success(&self, msg: impl Into<String>) {
-        let _ = self.tx.send(LogEntry::Success(msg.into()));
+    pub fn info(&self, msg: impl Into<String>) {
+        let _ = self.tx.send(LogEntry::Info(msg.into()));
     }
 
     pub fn warn(&self, msg: impl Into<String>) {
@@ -131,16 +152,86 @@ async fn open_log_file(path: &PathBuf) -> Option<tokio::fs::File> {
     }
 }
 
+/// アクション種別を最大4文字の短縮名に変換する。
+fn action_type_short(action_type: &str) -> &str {
+    match action_type {
+        "copy" => "copy",
+        "move" => "move",
+        "command" => "cmd",
+        "execute" => "exec",
+        "log" => "log",
+        other => {
+            if other.len() <= 4 { other } else { &other[..4] }
+        }
+    }
+}
+
+/// ファイルログ用 level カラム文字列（FILE_LEVEL_WIDTH 幅）を生成する。
+fn file_level_col(entry: &LogEntry) -> String {
+    match entry {
+        LogEntry::Match { .. } => format!("{:<width$}", "MATCH", width = FILE_LEVEL_WIDTH),
+        LogEntry::Action { index, total, action_type, .. } => {
+            let tree = if *index == *total { '└' } else { '├' };
+            let short = action_type_short(action_type);
+            let index_str = index.to_string();
+            let index_len = index_str.len();
+            // tree(1) + index + space(1) + type; truncate type to fit in FILE_LEVEL_WIDTH
+            let type_max = FILE_LEVEL_WIDTH.saturating_sub(1 + index_len + 1);
+            let type_part: String = short.chars().take(type_max).collect();
+            format!("{:<width$}", format!("{}{} {}", tree, index_str, type_part), width = FILE_LEVEL_WIDTH)
+        }
+        LogEntry::ActionOk { index, total, .. } => {
+            if *index == *total {
+                // 最終ステップ完了: 継続パイプなし
+                format!("{:<width$}", "   OK", width = FILE_LEVEL_WIDTH)
+            } else {
+                // 中間ステップ完了: 継続パイプあり
+                format!("{:<width$}", "│   OK", width = FILE_LEVEL_WIDTH)
+            }
+        }
+        LogEntry::Info(_) => format!("{:<width$}", "INFO", width = FILE_LEVEL_WIDTH),
+        LogEntry::Warn(_) => format!("{:<width$}", "WARN", width = FILE_LEVEL_WIDTH),
+        LogEntry::Error(_) => format!("{:<width$}", "ERROR", width = FILE_LEVEL_WIDTH),
+        LogEntry::Shutdown => unreachable!(),
+    }
+}
+
+/// ファイルログ用 events カラム文字列（FILE_EVENTS_WIDTH 幅）を生成する。
+/// MATCH エントリのみイベント名を出力し、それ以外は空白で埋める。
+fn file_events_col(entry: &LogEntry) -> String {
+    let s = match entry {
+        LogEntry::Match { events, .. } => format_events(events),
+        _ => String::new(),
+    };
+    format!("{:<width$}", s, width = FILE_EVENTS_WIDTH)
+}
+
+/// ファイルログ用 content カラムを生成する。
+fn file_content(entry: &LogEntry) -> String {
+    match entry {
+        LogEntry::Match { path, .. } => path.clone(),
+        LogEntry::Action { detail, .. } => detail.replace('\n', r"\n"),
+        LogEntry::ActionOk { msg, .. } => msg.clone(),
+        LogEntry::Info(msg) => msg.clone(),
+        LogEntry::Warn(msg) => msg.clone(),
+        LogEntry::Error(msg) => msg.clone(),
+        LogEntry::Shutdown => unreachable!(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn writer_task(
     mut rx: mpsc::UnboundedReceiver<LogEntry>,
     log_dir: String,
     log_file_name: String,
     level: LogLevel,
     log_rotation: LogRotation,
+    log_to_console: bool,
+    log_to_file: bool,
 ) {
     let mut current_date = Local::now().format("%Y%m%d").to_string();
     let log_path = build_log_path(&log_dir, &log_file_name);
-    let mut file = open_log_file(&log_path).await;
+    let mut file = if log_to_file { open_log_file(&log_path).await } else { None };
 
     while let Some(entry) = rx.recv().await {
         if matches!(entry, LogEntry::Shutdown) {
@@ -149,7 +240,7 @@ async fn writer_task(
 
         let now = Local::now();
         let today = now.format("%Y%m%d").to_string();
-        if matches!(log_rotation, LogRotation::Daily) && today != current_date {
+        if log_to_file && matches!(log_rotation, LogRotation::Daily) && today != current_date {
             if let Some(mut f) = file.take() {
                 let _ = f.flush().await;
             }
@@ -160,98 +251,94 @@ async fn writer_task(
 
         let ts = now.format("%Y-%m-%d %H:%M:%S").to_string();
 
-        match &entry {
-            LogEntry::Match { rule_name, path, events } => {
-                if !level_enabled(&level, &LogLevel::Info) {
-                    continue;
+        // ─── ファイルログ（4カラム固定幅フォーマット）───────────────────────
+        if log_to_file {
+            let file_line = match &entry {
+                LogEntry::Match { .. } | LogEntry::Action { .. } | LogEntry::ActionOk { .. }
+                | LogEntry::Info(_) | LogEntry::Warn(_) | LogEntry::Error(_) => {
+                    if !level_enabled_for_entry(&level, &entry) {
+                        String::new()
+                    } else {
+                        let lv = file_level_col(&entry);
+                        let ev = file_events_col(&entry);
+                        let ct = file_content(&entry);
+                        format!("{} │ {} │ {} │ {}\n", ts, lv, ev, ct)
+                    }
                 }
-                let event_str = format_events(events);
-                let file_line = format!(
-                    "[{ts}] [MATCH]   ルール={rule_name} | パス={path} | {event_str}\n"
-                );
-                let term_line = format!(
-                    "{}\n{} {}",
-                    SEPARATOR.bright_green().dimmed(),
-                    format!("[{ts}] [MATCH]").bright_green().bold(),
-                    format!("  ルール={rule_name} | パス={path} | {event_str}")
-                );
-                println!("{}", term_line);
+                LogEntry::Shutdown => unreachable!(),
+            };
+            if !file_line.is_empty() {
                 write_file(&mut file, &file_line).await;
             }
+        }
 
-            LogEntry::Action { index, total, action_type, detail } => {
-                if !level_enabled(&level, &LogLevel::Info) {
-                    continue;
+        // ─── ターミナル出力（カラー付き従来フォーマット）─────────────────────
+        if log_to_console {
+            match &entry {
+                LogEntry::Match { rule_name, path, events } => {
+                    if !level_enabled(&level, &LogLevel::Info) { continue; }
+                    let event_str = format_events(events);
+                    let term_line = format!(
+                        "{}\n{} {}",
+                        SEPARATOR.bright_green().dimmed(),
+                        format!("[{ts}] [MATCH]").bright_green().bold(),
+                        format!("  ルール={rule_name} | パス={path} | {event_str}")
+                    );
+                    println!("{}", term_line);
                 }
-                let file_line = format!(
-                    "[{ts}] [ACTION]  ({index}/{total}) {action_type}  {detail}\n"
-                );
-                let term_line = format!(
-                    "{} {}",
-                    format!("[{ts}] [ACTION]").blue().bold(),
-                    format!("  ({index}/{total}) {action_type}  {detail}")
-                );
-                println!("{}", term_line);
-                write_file(&mut file, &file_line).await;
-            }
 
-            LogEntry::Success(msg) => {
-                if !level_enabled(&level, &LogLevel::Info) {
-                    continue;
+                LogEntry::Action { index, total, action_type, detail } => {
+                    if !level_enabled(&level, &LogLevel::Info) { continue; }
+                    let term_line = format!(
+                        "{} {}",
+                        format!("[{ts}] [ACTION]").blue().bold(),
+                        format!("  ({index}/{total}) {action_type}  {detail}")
+                    );
+                    println!("{}", term_line);
                 }
-                let file_line = format!("[{ts}] [SUCCESS] {msg}\n");
-                let term_line = format!(
-                    "{} {}",
-                    format!("[{ts}] [SUCCESS]").green().bold(),
-                    msg
-                );
-                println!("{}", term_line);
-                write_file(&mut file, &file_line).await;
-            }
 
-            LogEntry::Info(msg) => {
-                if !level_enabled(&level, &LogLevel::Info) {
-                    continue;
+                LogEntry::ActionOk { msg, .. } => {
+                    if !level_enabled(&level, &LogLevel::Info) { continue; }
+                    let term_line = format!(
+                        "{} {}",
+                        format!("[{ts}] [OK]    ").green().bold(),
+                        msg
+                    );
+                    println!("{}", term_line);
                 }
-                let file_line = format!("[{ts}] [INFO]    {msg}\n");
-                let term_line = format!(
-                    "{} {}",
-                    format!("[{ts}] [INFO]").cyan(),
-                    msg
-                );
-                println!("{}", term_line);
-                write_file(&mut file, &file_line).await;
-            }
 
-            LogEntry::Warn(msg) => {
-                if !level_enabled(&level, &LogLevel::Warn) {
-                    continue;
+                LogEntry::Info(msg) => {
+                    if !level_enabled(&level, &LogLevel::Info) { continue; }
+                    let term_line = format!(
+                        "{} {}",
+                        format!("[{ts}] [INFO]").cyan(),
+                        msg
+                    );
+                    println!("{}", term_line);
                 }
-                let file_line = format!("[{ts}] [WARN]    {msg}\n");
-                let term_line = format!(
-                    "{} {}",
-                    format!("[{ts}] [WARN]").yellow().bold(),
-                    msg
-                );
-                println!("{}", term_line);
-                write_file(&mut file, &file_line).await;
-            }
 
-            LogEntry::Error(msg) => {
-                if !level_enabled(&level, &LogLevel::Error) {
-                    continue;
+                LogEntry::Warn(msg) => {
+                    if !level_enabled(&level, &LogLevel::Warn) { continue; }
+                    let term_line = format!(
+                        "{} {}",
+                        format!("[{ts}] [WARN]").yellow().bold(),
+                        msg
+                    );
+                    println!("{}", term_line);
                 }
-                let file_line = format!("[{ts}] [ERROR]   {msg}\n");
-                let term_line = format!(
-                    "{} {}",
-                    format!("[{ts}] [ERROR]").red().bold(),
-                    msg
-                );
-                eprintln!("{}", term_line);
-                write_file(&mut file, &file_line).await;
-            }
 
-            LogEntry::Shutdown => unreachable!(),
+                LogEntry::Error(msg) => {
+                    if !level_enabled(&level, &LogLevel::Error) { continue; }
+                    let term_line = format!(
+                        "{} {}",
+                        format!("[{ts}] [ERROR]").red().bold(),
+                        msg
+                    );
+                    eprintln!("{}", term_line);
+                }
+
+                LogEntry::Shutdown => unreachable!(),
+            }
         }
     }
 
@@ -267,6 +354,15 @@ async fn write_file(file: &mut Option<tokio::fs::File>, line: &str) {
             eprintln!("{}", format!("[{ts}] [ERROR] ログ書き込み失敗: {e}").red().bold());
         }
     }
+}
+
+fn level_enabled_for_entry(current: &LogLevel, entry: &LogEntry) -> bool {
+    let required = match entry {
+        LogEntry::Warn(_) => &LogLevel::Warn,
+        LogEntry::Error(_) => &LogLevel::Error,
+        _ => &LogLevel::Info,
+    };
+    level_enabled(current, required)
 }
 
 fn level_enabled(current: &LogLevel, required: &LogLevel) -> bool {
@@ -294,5 +390,5 @@ fn format_events(events: &HashSet<crate::config::Event>) -> String {
         })
         .collect();
     names.sort();
-    names.join(", ")
+    names.join(",")
 }

--- a/cat-watcher/src/logger.rs
+++ b/cat-watcher/src/logger.rs
@@ -56,7 +56,10 @@ impl Logger {
         colored::control::set_virtual_terminal(true).ok();
         colored::control::set_override(true);
 
-        let level = global.log_level.clone();
+        let terminal_level = global.terminal_log_level.clone()
+            .unwrap_or_else(|| global.log_level.clone());
+        let file_level = global.file_log_level.clone()
+            .unwrap_or_else(|| global.log_level.clone());
         let log_dir = global.log_dir.clone();
         let log_file_name = global.log_file_name.clone();
         let log_rotation = global.log_rotation.clone();
@@ -67,10 +70,32 @@ impl Logger {
             rx,
             log_dir,
             log_file_name,
-            level,
+            terminal_level,
+            file_level,
             log_rotation,
             log_to_console,
             log_to_file,
+        ));
+        Ok((Self { tx }, handle))
+    }
+
+    /// ルール別ログ専用ロガー（ファイル出力のみ、コンソール出力なし）。
+    pub fn for_rule(
+        log_dir: String,
+        log_file_name: String,
+        log_rotation: LogRotation,
+        file_level: LogLevel,
+    ) -> Result<(Self, tokio::task::JoinHandle<()>), AppError> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(writer_task(
+            rx,
+            log_dir,
+            log_file_name,
+            LogLevel::Error, // terminal は無効（log_to_console=false のため参照されない）
+            file_level,
+            log_rotation,
+            false, // log_to_console
+            true,  // log_to_file
         ));
         Ok((Self { tx }, handle))
     }
@@ -224,7 +249,8 @@ async fn writer_task(
     mut rx: mpsc::UnboundedReceiver<LogEntry>,
     log_dir: String,
     log_file_name: String,
-    level: LogLevel,
+    terminal_level: LogLevel,
+    file_level: LogLevel,
     log_rotation: LogRotation,
     log_to_console: bool,
     log_to_file: bool,
@@ -256,7 +282,7 @@ async fn writer_task(
             let file_line = match &entry {
                 LogEntry::Match { .. } | LogEntry::Action { .. } | LogEntry::ActionOk { .. }
                 | LogEntry::Info(_) | LogEntry::Warn(_) | LogEntry::Error(_) => {
-                    if !level_enabled_for_entry(&level, &entry) {
+                    if !level_enabled_for_entry(&file_level, &entry) {
                         String::new()
                     } else {
                         let lv = file_level_col(&entry);
@@ -276,7 +302,7 @@ async fn writer_task(
         if log_to_console {
             match &entry {
                 LogEntry::Match { rule_name, path, events } => {
-                    if !level_enabled(&level, &LogLevel::Info) { continue; }
+                    if !level_enabled(&terminal_level, &LogLevel::Info) { continue; }
                     let event_str = format_events(events);
                     let term_line = format!(
                         "{}\n{} {}",
@@ -288,7 +314,7 @@ async fn writer_task(
                 }
 
                 LogEntry::Action { index, total, action_type, detail } => {
-                    if !level_enabled(&level, &LogLevel::Info) { continue; }
+                    if !level_enabled(&terminal_level, &LogLevel::Info) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [ACTION]").blue().bold(),
@@ -298,7 +324,7 @@ async fn writer_task(
                 }
 
                 LogEntry::ActionOk { msg, .. } => {
-                    if !level_enabled(&level, &LogLevel::Info) { continue; }
+                    if !level_enabled(&terminal_level, &LogLevel::Info) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [OK]    ").green().bold(),
@@ -308,7 +334,7 @@ async fn writer_task(
                 }
 
                 LogEntry::Info(msg) => {
-                    if !level_enabled(&level, &LogLevel::Info) { continue; }
+                    if !level_enabled(&terminal_level, &LogLevel::Info) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [INFO]").cyan(),
@@ -318,7 +344,7 @@ async fn writer_task(
                 }
 
                 LogEntry::Warn(msg) => {
-                    if !level_enabled(&level, &LogLevel::Warn) { continue; }
+                    if !level_enabled(&terminal_level, &LogLevel::Warn) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [WARN]").yellow().bold(),
@@ -328,7 +354,7 @@ async fn writer_task(
                 }
 
                 LogEntry::Error(msg) => {
-                    if !level_enabled(&level, &LogLevel::Error) { continue; }
+                    if !level_enabled(&terminal_level, &LogLevel::Error) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [ERROR]").red().bold(),

--- a/cat-watcher/src/router.rs
+++ b/cat-watcher/src/router.rs
@@ -52,10 +52,12 @@ pub struct CompiledRule{
 	pub exclude_glob_set: Option<GlobSet>,
 	pub regexes: Option<Regex>,
 	pub actions: Vec<ActionConfig>,
+	pub rule_logger: Option<Arc<Logger>>,
 }
 
-pub fn compile_rules(rules: &[Rule]) -> Result<Vec<CompiledRule>, AppError> {
+pub fn compile_rules(rules: &[Rule], global: &Global) -> Result<(Vec<CompiledRule>, Vec<tokio::task::JoinHandle<()>>), AppError> {
 	let mut compiled_rules = Vec::new();
+	let mut log_handles = Vec::new();
 	for rule in rules{
 		let glob_set = if let Some(patterns) = &rule.watch.patterns {
 			let mut builder = GlobSetBuilder::new();
@@ -85,6 +87,26 @@ pub fn compile_rules(rules: &[Rule]) -> Result<Vec<CompiledRule>, AppError> {
 			None
 		};
 		
+		let rule_logger = if let Some(rule_log) = &rule.log {
+			if rule_log.enabled {
+				let log_dir = rule_log.log_dir.clone()
+					.unwrap_or_else(|| global.log_dir.clone());
+				let log_file_name = rule_log.log_file_name.clone()
+					.unwrap_or_else(|| global.log_file_name.clone());
+				let log_rotation = rule_log.log_rotation.clone()
+					.unwrap_or_else(|| global.log_rotation.clone());
+				let file_level = global.file_log_level.clone()
+					.unwrap_or_else(|| global.log_level.clone());
+				let (logger, handle) = Logger::for_rule(log_dir, log_file_name, log_rotation, file_level)?;
+				log_handles.push(handle);
+				Some(Arc::new(logger))
+			} else {
+				None
+			}
+		} else {
+			None
+		};
+
 		compiled_rules.push(CompiledRule {
 			name: rule.name.clone(),
 			enabled: rule.enabled,
@@ -97,9 +119,10 @@ pub fn compile_rules(rules: &[Rule]) -> Result<Vec<CompiledRule>, AppError> {
 			exclude_glob_set,
 			regexes,
 			actions: rule.actions.clone(),
+			rule_logger,
 		});
 	}
-	Ok(compiled_rules)
+	Ok((compiled_rules, log_handles))
 }
 
 fn evaluate_rule(
@@ -253,6 +276,13 @@ pub async fn run_router(
                             path.display().to_string(),
                             detected_events.clone(),
                         );
+                        if let Some(rl) = &rule.rule_logger {
+                            rl.log_match(
+                                &rule.name,
+                                path.display().to_string(),
+                                detected_events.clone(),
+                            );
+                        }
 
                         let watch_path = PathBuf::from(&rule.watch_path);
                         if let Err(e) = crate::actions::execute_chain(
@@ -261,11 +291,18 @@ pub async fn run_router(
                             &watch_path,
                             global,
                             Arc::clone(&log),
+                            rule.rule_logger.clone(),
                         ).await {
                             log.error(format!(
                                 "アクションチェーン実行エラー: ルール={}, パス={}, エラー={}",
                                 rule.name, path.display(), e
                             ));
+                            if let Some(rl) = &rule.rule_logger {
+                                rl.error(format!(
+                                    "アクションチェーン実行エラー: パス={}, エラー={}",
+                                    path.display(), e
+                                ));
+                            }
                         }
                     }
                 }
@@ -307,6 +344,7 @@ mod tests {
             exclude_glob_set: None,
             regexes: None,
             actions: vec![],
+            rule_logger: None,
         }
     }
 

--- a/cat-watcher/src/watcher.rs
+++ b/cat-watcher/src/watcher.rs
@@ -89,7 +89,17 @@ pub async fn start_watching(
         })?;
     }
 
-    let compiled_rules = crate::router::compile_rules(rules)?;
+    let (compiled_rules, rule_log_handles) = crate::router::compile_rules(rules, global)?;
     crate::router::run_router(rx, &compiled_rules, global, Arc::clone(&log)).await?;
+
+    // ルール別ロガーをシャットダウン
+    for rule in &compiled_rules {
+        if let Some(rl) = &rule.rule_logger {
+            rl.shutdown();
+        }
+    }
+    for handle in rule_log_handles {
+        let _ = handle.await;
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

ログ機能をまとめて拡充する。元 PR #29 から 2 コミットを cherry-pick + 罫線ズレ修正コミットで構成。

### コミット 1: 4列固定幅フォーマット + log_to_console/log_to_file (#20, #22)

- ファイルログを \`timestamp │ level(7列) │ events(27列) │ content\` の 4 列固定幅レイアウトに刷新
  - MATCH 行はイベント名 (Create,Modify など) を events 列に出力
  - アクションチェーンを \`├N type\` (中間) / \`└N type\` (最終) のツリー記号で表現
  - \`ActionOk\` は \`│   OK\` (継続) / \`   OK\` (完了) で表現
- 複数行コマンドを \`\\n\` エスケープしてファイルログでは 1 行に収める (#20)
- \`Global\` に \`log_to_console\` / \`log_to_file\` を追加 (default true、serde で後方互換) (#22)
- \`LogEntry::Success\` を \`LogEntry::ActionOk { index, total, msg }\` に置換
- 既存のターミナル色付きフォーマットは維持

### コミット 2: terminal/file 個別レベル + ルール別ログ (#25, #27)

- #25: \`terminal_log_level\` / \`file_log_level\` を追加 (未設定なら \`log_level\` を継承)
- #27: \`[rules.log]\` セクション (enabled / log_dir / log_file_name / log_rotation) を追加
  - 各ルールでファイル専用ロガーを別に立てる (\`Logger::for_rule()\` コンストラクタ)
  - 監視終了時 (Ctrl+C) にルール別ロガーをシャットダウン
  - \`execute_chain\` が \`Option<Arc<Logger>>\` のルール別ロガーを受け取り、アクションログを二重出力

### コミット 3: 罫線ズレ修正

PR-C 検証中に発見した不具合の修正。

- 4 列フォーマットの罫線文字 (\`'└'\` \`'├'\` \`'│'\`) は East Asian Ambiguous で、CJK ロケールのターミナルでは 2 列幅となるが、Rust 標準の \`format!\` は char 数で揃えるため列が 1 つズレていた
- \`unicode-width = "0.2"\` クレートを依存に追加
- \`pad_left_display()\` ヘルパーで \`width_cjk()\` 基準のパディングに統一
- 5 件のユニットテスト追加 (ASCII / EAW / 中間ステップ / オーバーフロー / レベル整合)

## Closes

Closes #20
Closes #22
Closes #25
Closes #27

## Test plan

- [x] \`cargo test --package cat-watcher\` で 126 件全パス
- [x] Win11 ローカル C: ドライブで \`Run-CatWatcherTest.ps1\` 実機検証
  - 4 列固定幅レイアウトが意図通り出力される
  - 罫線文字の縦が揃う (修正前は \`└1 log\` の行だけ 1 列右にズレていた)
  - Create / Modify / Delete / Rename / recursive 検知に回帰なし

## 関連

PR #29 を 3 つに分割した 3 つ目 (最後)。

- PR #33 (merged): notify-fork で RDExW
- PR #35 (merged): #23 #24 #30 修正
- PR (このPR): #20 #22 #25 #27 ログ機能拡充

このPRがマージされたら PR #29 を close する予定。

## 含めなかったもの

- \`raw-events/\` 観察ツール、\`dist/\` の同梱 exe、probe ワークフロー
  → 元 PR #29 にあったがリポジトリ整理方針 (PR #32) に従い破棄

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>