### PR TITLE
chore: バージョンを v1.1.0 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cat-watcher"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "chrono",

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-watcher"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
このバージョンには以下の改善が含まれる:

- feat: notify-fork で Windows 10 1709+ の ReadDirectoryChangesExW を使用、Create/Remove イベントで File/Folder 種別を区別可能 (#33)
- fix: target=file / target=directory + delete でイベントが 検知されない問題を解消 (#23 / #24)
- fix: rename 操作を Rename イベントとして検知 (#30)
- feat: ファイルログを 4 列固定幅フォーマットに刷新、アクション チェーンをツリー記号で表現 (#20 / #22)
- feat: terminal / file 個別ログレベル (#25)
- feat: ルール別ログファイル出力 (#27)
- fix: 日本語ロケールターミナルで罫線文字が縦に揃わない問題を unicode-width 列幅基準のパディングで解消
- chore: リポジトリ整理 (.gitignore, raw-events 削除等)

main への push 後、release.yml が自動で v1.1.0 タグを作成し
GitHub Releases にバイナリ (Win x64 / Linux x64) を公開する。