### PR TITLE
docs: README を v1.1.0 向けに更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,13 +197,14 @@ shell, command, program, args, working_dir, message
 **ファイル出力**（4列固定幅フォーマット）
 
 ```
-2026-05-07 10:30:20 │ MATCH   │ Create, Modify              │ ルール=csv-backup | パス=C:\data\report.csv
-2026-05-07 10:30:20 │ ACTION  │                             │ (1/3) log
-2026-05-07 10:30:20 │ INFO    │                             │ 検知: report.csv
-2026-05-07 10:30:20 │ ACTION  │                             │ (2/3) copy  C:\data\report.csv → D:\backup\20260507
-2026-05-07 10:30:20 │ OK      │                             │ コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
-2026-05-07 10:30:20 │ ACTION  │                             │ (3/3) command  shell=powershell  cmd=Write-Host 'Backed up: ...'
-2026-05-07 10:30:20 │ OK      │                             │ コマンド完了
+2026-05-07 10:30:20 │ INFO    │                             │ cat-watcher 起動
+2026-05-07 10:30:20 │ MATCH   │ Create,Modify               │ C:\data\report.csv
+2026-05-07 10:30:20 │ ├1 log │                             │ 
+2026-05-07 10:30:20 │ │   OK │                             │ 検知: report.csv
+2026-05-07 10:30:20 │ ├2 cop │                             │ C:\data\report.csv → D:\backup\{Date}
+2026-05-07 10:30:20 │ │   OK │                             │ コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
+2026-05-07 10:30:20 │ └3 cmd │                             │ shell=powershell  cmd=Write-Host 'Backed up: ...'
+2026-05-07 10:30:20 │    OK   │                             │ 起動
 ```
 
 `log_to_console = false` でターミナル出力を、`log_to_file = false` でファイル出力を無効にできます。`terminal_log_level` / `file_log_level` でそれぞれのログレベルを個別に設定することもできます。

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 - **整合性検証**: BLAKE3 ハッシュでコピー後のファイル一致を確認
 - **リトライ機構**: ロック等で失敗したアクションを自動再試行
 - **ログローテーション**: 日次でログファイルを切り替え（`log_rotation = "never"` で固定ファイルにも対応）
+- **ルール別ログ**: ルールごとに独立したログファイルへ出力（`[rules.log]` セクションで設定）
+- **ログ出力先の個別制御**: コンソール・ファイルを個別に有効/無効、ログレベルも別々に指定可能
 - **テンプレート生成**: `--init` で設定ファイルのひな形をすぐに出力できる
 - **全件エラー報告**: 設定ファイルに複数の問題があっても、1 回の起動で全エラーをまとめて表示
 - **大文字小文字不区別**: 設定値は `create` / `Create` / `CREATE` のいずれでも動作
@@ -65,6 +67,14 @@ log_file_name     = "cat-watcher_{Date}.log"  # {Date} / {DateTime} を埋め込
 log_rotation      = "daily"                   # daily / never
 retry_count       = 3
 retry_interval_ms = 1000
+
+# ログ出力先の制御（省略時はどちらも true）
+log_to_console    = true
+log_to_file       = true
+
+# コンソール・ファイルで異なるログレベルを使いたい場合に設定（省略時は log_level を使用）
+# terminal_log_level = "info"
+# file_log_level     = "debug"
 ```
 
 ### rules.toml（ルール定義）
@@ -83,6 +93,14 @@ patterns         = ["*.csv", "*.xlsx"]   # glob（regex と排他）
 # regex          = ".*\\.csv$"           # 正規表現（patterns と排他）
 exclude_patterns = ["temp_*"]
 events           = ["create", "modify"]  # create / modify / delete / rename
+
+# ── ルール別ログ（省略可）──────────────────────────────────────────────────
+# このルールにマッチしたイベントをルール専用のログファイルにも書き出す
+[rules.log]
+enabled       = true
+log_dir       = "D:\\logs\\csv-backup"
+log_file_name = "csv-backup_{Date}.log"  # {Date} / {DateTime} を埋め込み可
+log_rotation  = "daily"                  # daily / never
 
 # ──────────── アクションチェーン ────────────
 [[rules.actions]]
@@ -161,7 +179,9 @@ shell, command, program, args, working_dir, message
 
 ## ログ
 
-すべてのログ行は `[YYYY-MM-DD HH:MM:SS] [LEVEL] ...` のフォーマットでターミナルとファイルに出力されます。
+ターミナルとファイルでフォーマットが異なります。
+
+**ターミナル出力**（カラー付き）
 
 ```
 ──────────────────────────────────────────────────────────────
@@ -169,9 +189,24 @@ shell, command, program, args, working_dir, message
 [2026-05-07 10:30:20] [ACTION]  (1/3) log
 [2026-05-07 10:30:20] [INFO]    検知: report.csv
 [2026-05-07 10:30:20] [ACTION]  (2/3) copy  C:\data\report.csv → D:\backup\20260507
-[2026-05-07 10:30:20] [SUCCESS] コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
+[2026-05-07 10:30:20] [OK]      コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
 [2026-05-07 10:30:20] [ACTION]  (3/3) command  shell=powershell  cmd=Write-Host 'Backed up: ...'
+[2026-05-07 10:30:20] [OK]      コマンド完了
 ```
+
+**ファイル出力**（4列固定幅フォーマット）
+
+```
+2026-05-07 10:30:20 │ MATCH   │ Create, Modify              │ ルール=csv-backup | パス=C:\data\report.csv
+2026-05-07 10:30:20 │ ACTION  │                             │ (1/3) log
+2026-05-07 10:30:20 │ INFO    │                             │ 検知: report.csv
+2026-05-07 10:30:20 │ ACTION  │                             │ (2/3) copy  C:\data\report.csv → D:\backup\20260507
+2026-05-07 10:30:20 │ OK      │                             │ コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
+2026-05-07 10:30:20 │ ACTION  │                             │ (3/3) command  shell=powershell  cmd=Write-Host 'Backed up: ...'
+2026-05-07 10:30:20 │ OK      │                             │ コマンド完了
+```
+
+`log_to_console = false` でターミナル出力を、`log_to_file = false` でファイル出力を無効にできます。`terminal_log_level` / `file_log_level` でそれぞれのログレベルを個別に設定することもできます。
 
 ## 開発
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ cat-watcher --init rules  --output config\rules.toml
 cat-watcher --global global.toml --rules rules.toml --validate
 cat-watcher --global global.toml --rules rules.toml
 
+# 引数の短縮系
+cat-watcher -g global.toml -r rules.toml
+
 # CSV をルール TOML に変換
 cat-watcher --from-csv rules.csv --output rules.toml
 ```
@@ -163,6 +166,7 @@ working_dir = ""
 ## CSV からの変換
 
 CSV の列順（1 行目はヘッダー、自動でスキップ）：
+** 未検証... **
 
 ```
 rule_name, enabled, watch_path, recursive, target, include_hidden,
@@ -199,11 +203,11 @@ shell, command, program, args, working_dir, message
 ```
 2026-05-07 10:30:20 │ INFO    │                             │ cat-watcher 起動
 2026-05-07 10:30:20 │ MATCH   │ Create,Modify               │ C:\data\report.csv
-2026-05-07 10:30:20 │ ├1 log │                             │ 
-2026-05-07 10:30:20 │ │   OK │                             │ 検知: report.csv
-2026-05-07 10:30:20 │ ├2 cop │                             │ C:\data\report.csv → D:\backup\{Date}
-2026-05-07 10:30:20 │ │   OK │                             │ コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
-2026-05-07 10:30:20 │ └3 cmd │                             │ shell=powershell  cmd=Write-Host 'Backed up: ...'
+2026-05-07 10:30:20 │ ├1 log  │                             │ 
+2026-05-07 10:30:20 │ │   OK  │                             │ 検知: report.csv
+2026-05-07 10:30:20 │ ├2 cop  │                             │ C:\data\report.csv → D:\backup\{Date}
+2026-05-07 10:30:20 │ │   OK  │                             │ コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
+2026-05-07 10:30:20 │ └3 cmd  │                             │ shell=powershell  cmd=Write-Host 'Backed up: ...'
 2026-05-07 10:30:20 │    OK   │                             │ 起動
 ```
 


### PR DESCRIPTION
- global.toml に log_to_console / log_to_file / terminal_log_level / file_log_level を追加
- rules.toml にルール別ログ ([rules.log]) セクションの例を追加
- ログセクションをターミナル（カラー付き）とファイル（4列固定幅）に分けて説明
- [SUCCESS] → [OK] に合わせてサンプル出力を修正
- 主な機能にルール別ログ・ログ出力先の個別制御を追記

https://claude.ai/code/session_01RaphfKuMvqVjUJV1PhEBbw