### PR TITLE
fix: UNC/ネットワークパスの監視イベント検知を修正

### DIFF
--- a/cat-watcher/src/watcher.rs
+++ b/cat-watcher/src/watcher.rs
@@ -11,7 +11,16 @@ use crate::logger::Logger;
 
 fn strip_unc_prefix(path: &PathBuf) -> String {
     let s = path.display().to_string();
-    s.strip_prefix(r"\\?\").unwrap_or(&s).to_string()
+    // canonicalize() は UNC パスを \\?\UNC\server\share 形式に変換する。
+    // \\?\UNC\ → \\ に変換して \\server\share の通常 UNC 形式に戻す。
+    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        return format!(r"\\{}", rest);
+    }
+    // ローカルパスの拡張形式 \\?\C:\... → C:\... に変換。
+    if let Some(rest) = s.strip_prefix(r"\\?\") {
+        return rest.to_string();
+    }
+    s
 }
 
 pub async fn start_watching(

--- a/notify-fork/src/windows.rs
+++ b/notify-fork/src/windows.rs
@@ -20,8 +20,8 @@ use std::slice;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use windows_sys::Win32::Foundation::{
-    CloseHandle, ERROR_ACCESS_DENIED, ERROR_OPERATION_ABORTED, ERROR_SUCCESS, HANDLE,
-    INVALID_HANDLE_VALUE, WAIT_OBJECT_0,
+    CloseHandle, ERROR_ACCESS_DENIED, ERROR_OPERATION_ABORTED, ERROR_SUCCESS, GetLastError,
+    HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0,
 };
 use windows_sys::Win32::Storage::FileSystem::{
     CreateFileW, FILE_ACTION_ADDED, FILE_ACTION_MODIFIED,
@@ -409,10 +409,21 @@ fn start_read(
         };
 
         if ret == 0 {
-            // error reading. retransmute request memory to allow drop.
-            // Because of the error, ownership of the `overlapped` alloc was not passed
-            // over to `ReadDirectoryChangesW`.
-            // So we can claim ownership back.
+            // The ReadDirectoryChanges call failed immediately (not async).
+            // Ownership of overlapped/request was NOT transferred to the OS,
+            // so we reclaim both before releasing the semaphore.
+            //
+            // Known cause: ReadDirectoryChangesExW with ReadDirectoryNotifyExtendedInformation
+            // (class 2) is unsupported on UNC/network paths — GetLastError() returns
+            // ERROR_INVALID_PARAMETER (87) or ERROR_NOT_SUPPORTED (50) in that case.
+            let err = GetLastError();
+            log::error!(
+                "ReadDirectoryChanges call failed (err={}) for directory `{}` — \
+                 UNC/network paths are not supported by ReadDirectoryChangesExW with \
+                 ExtendedInformation class; watch will not fire for this path.",
+                err,
+                rd.dir.display(),
+            );
             let _overlapped = Box::from_raw(overlapped);
             let request = Box::from_raw(request);
             ReleaseSemaphore(request.data.complete_sem, 1, ptr::null_mut());

--- a/notify-fork/src/windows.rs
+++ b/notify-fork/src/windows.rs
@@ -120,6 +120,11 @@ struct ReadData {
     file: Option<PathBuf>, // if a file is being watched, this is its full path
     complete_sem: HANDLE,
     is_recursive: bool,
+    // true  → ReadDirectoryChangesExW (RDNEI class=2, NTFS local only)
+    // false → ReadDirectoryChangesW   (UNC/network paths, non-NTFS, old Windows)
+    // Starts as true when ExW is available; flipped to false on first failure so
+    // subsequent reads skip the ExW attempt entirely.
+    use_extended: bool,
 }
 
 struct ReadDirectoryRequest {
@@ -305,6 +310,7 @@ impl ReadDirectoryChangesServer {
             file: wf,
             complete_sem: semaphore,
             is_recursive,
+            use_extended: rdcexw_fn().is_some(),
         };
         let ws = WatchState {
             dir_handle: handle,
@@ -378,24 +384,70 @@ fn start_read(
         let request = Box::leak(request);
         (*overlapped).hEvent = request as *mut _ as _;
 
-        let ret = if let Some(rdcexw) = rdcexw_fn() {
+        let ret = if request.data.use_extended {
             // Windows 10 1709+ / Server 2019+:
             // ReadDirectoryChangesExW で FILE_NOTIFY_EXTENDED_INFORMATION を取得。
             // FileAttributes フィールドで Create/Remove 時のファイル種別が判別できる。
-            rdcexw(
-                handle,
-                request.buffer.as_mut_ptr() as *mut c_void,
-                BUF_SIZE,
-                monitor_subdir,
-                flags,
-                &mut 0u32 as *mut u32,
-                overlapped,
-                Some(handle_event),
-                RDNEI,
-            )
+            // NTFS ローカルパスのみ対応。UNC/非 NTFS では ERROR_INVALID_FUNCTION 等で失敗する。
+            if let Some(rdcexw) = rdcexw_fn() {
+                let r = rdcexw(
+                    handle,
+                    request.buffer.as_mut_ptr() as *mut c_void,
+                    BUF_SIZE,
+                    monitor_subdir,
+                    flags,
+                    &mut 0u32 as *mut u32,
+                    overlapped,
+                    Some(handle_event),
+                    RDNEI,
+                );
+                if r != 0 {
+                    r
+                } else {
+                    // ExW 失敗 (UNC/非 NTFS 等) → ReadDirectoryChangesW にフォールバック。
+                    // use_extended を false にすることで以降の start_read 呼び出しで
+                    // ExW を再試行しない。
+                    // Create/Remove は Any サブタイプになる; Delete は target=both でのみ発火。
+                    let err = GetLastError();
+                    log::warn!(
+                        "ReadDirectoryChangesExW failed (err={}) for `{}`, \
+                         falling back to ReadDirectoryChangesW — \
+                         UNC/network paths and non-NTFS file systems are not supported \
+                         by ExtendedInformation class. \
+                         Create/Remove events will use Any subtype; \
+                         Delete events fire only when target=both.",
+                        err,
+                        rd.dir.display(),
+                    );
+                    (*request).data.use_extended = false;
+                    ReadDirectoryChangesW(
+                        handle,
+                        request.buffer.as_mut_ptr() as *mut c_void,
+                        BUF_SIZE,
+                        monitor_subdir,
+                        flags,
+                        &mut 0u32 as *mut u32,
+                        overlapped,
+                        Some(handle_event),
+                    )
+                }
+            } else {
+                // rdcexw_fn() が None のはずがない (use_extended は is_some() で初期化) が、
+                // 安全のため W にフォールバック。
+                (*request).data.use_extended = false;
+                ReadDirectoryChangesW(
+                    handle,
+                    request.buffer.as_mut_ptr() as *mut c_void,
+                    BUF_SIZE,
+                    monitor_subdir,
+                    flags,
+                    &mut 0u32 as *mut u32,
+                    overlapped,
+                    Some(handle_event),
+                )
+            }
         } else {
-            // 旧 Windows フォールバック: ReadDirectoryChangesW。
-            // Create/Remove イベントは Any サブタイプで通知される。
+            // 旧 Windows フォールバック、または ExW 失敗後の再呼び出し。
             ReadDirectoryChangesW(
                 handle,
                 request.buffer.as_mut_ptr() as *mut c_void,
@@ -409,18 +461,11 @@ fn start_read(
         };
 
         if ret == 0 {
-            // The ReadDirectoryChanges call failed immediately (not async).
-            // Ownership of overlapped/request was NOT transferred to the OS,
-            // so we reclaim both before releasing the semaphore.
-            //
-            // Known cause: ReadDirectoryChangesExW with ReadDirectoryNotifyExtendedInformation
-            // (class 2) is unsupported on UNC/network paths — GetLastError() returns
-            // ERROR_INVALID_PARAMETER (87) or ERROR_NOT_SUPPORTED (50) in that case.
+            // ReadDirectoryChanges が即時失敗。overlapped/request の所有権は OS に渡っていないので
+            // ここで回収してセマフォを解放する。
             let err = GetLastError();
             log::error!(
-                "ReadDirectoryChanges call failed (err={}) for directory `{}` — \
-                 UNC/network paths are not supported by ReadDirectoryChangesExW with \
-                 ExtendedInformation class; watch will not fire for this path.",
+                "ReadDirectoryChangesW failed (err={}) for `{}` — watch will not fire for this path.",
                 err,
                 rd.dir.display(),
             );
@@ -485,7 +530,7 @@ unsafe extern "system" fn handle_event(
         }
     }
 
-    if rdcexw_fn().is_some() {
+    if request.data.use_extended {
         // ── ExW パス: FILE_NOTIFY_EXTENDED_INFORMATION ──────────────────────
         // FileAttributes フィールドでファイル/ディレクトリを区別する。
         // Wine では 16bit (WCHAR) 境界にアラインされるため read_unaligned を使う。


### PR DESCRIPTION
## 概要

`ReadDirectoryChangesExW` (class=2 RDNEI) は NTFS ローカルパス専用の API であり、UNC/SMB ネットワークパスでは `ERROR_INVALID_FUNCTION` 等で即時失敗する。
この失敗がサイレントに握り潰されていたため、ネットワークパス上のイベントが一切検知されない問題があった。

## 変更内容

### 1. ExW 失敗時のエラーログ追加 (`notify-fork/src/windows.rs`)

`start_read` で `ReadDirectoryChangesExW` が即時失敗 (ret=0) した場合、`GetLastError()` のエラーコードとパスをログに出力するよう修正。
それまで無音で監視が停止していた問題を修正。

### 2. UNC/非 NTFS パスで `ReadDirectoryChangesW` へフォールバック (`notify-fork/src/windows.rs`)

- `ReadData` に `use_extended: bool` フィールドを追加し、パスごとに使用 API を追跡
- ExW が失敗した場合、WARN ログを出力して `ReadDirectoryChangesW` にフォールバック
- 以降の `start_read` 呼び出しでは ExW を再試行しない (`use_extended=false` を引き継ぐ)
- `handle_event` のパース分岐を `rdcexw_fn().is_some()` → `request.data.use_extended` に変更

**UNC パス上での動作:**

| イベント | target=both | target=file | target=directory |
|---|---|---|---|
| 作成 | ✅ | ✅ | ✅ |
| 削除 | ✅ | ❌ | ❌ |
| リネーム | ✅ | ✅ | ✅ |
| 書き込み | ✅ | ✅ | ✅ |

削除が `target=both` のみとなるのは、`ReadDirectoryChangesW` では `FileAttributes` が得られず、削除後にパスが消えているため種別判定が不能なため（旧 Windows / Server 2016 と同等の動作）。

### 3. ログの UNC プレフィックス除去修正 (`cat-watcher/src/watcher.rs`)

`canonicalize()` が UNC パスを `\\?\UNC\server\share` 形式に変換するため、起動時ログに `UNC\10.0.0.1\c$` のように `UNC` が残っていた問題を修正。

- `\\?\UNC\server\share` → `\\server\share`
- `\\?\C:\path` → `C:\path`（従来通り）

## テスト方法

- ローカルパス（NTFS）: ExW class=2 が使われ、Create/Remove で File/Folder 種別が正確に通知されることを確認
- UNC パス (`\\server\share\...`): WARN ログが出て W にフォールバックし、作成・リネーム・書き込みイベントが検知されることを確認
- 旧 Windows (1709 未満): ExW が GetProcAddress で未検出となり、W が直接使われることを確認

https://claude.ai/code/session_01DF23cFZ8dcJMBwAX5deeLa