### PR TITLE
feat: パターンマッチング対称設計の完成 (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,12 @@ target           = "file"                # file / directory / both
 include_hidden   = false
 patterns         = ["*.csv", "*.xlsx"]   # glob（regex と排他）
 # regex          = ".*\\.csv$"           # 正規表現（patterns と排他）
-exclude_patterns = ["temp_*"]
+exclude_patterns = ["temp_*"]            # glob（exclude_regex と排他）
+# exclude_regex  = "^temp_"             # 正規表現（exclude_patterns と排他）
+dir_patterns     = ["incoming", "drop"]  # 包含フォルダ名 glob（dir_regex と排他）
+# dir_regex      = "^drop_\\d+"         # 包含フォルダ名 正規表現（dir_patterns と排他）
+exclude_dir_patterns = ["node_modules"]  # 除外フォルダ名 glob（exclude_dir_regex と排他）
+# exclude_dir_regex  = "^\\..*"         # 除外フォルダ名 正規表現（exclude_dir_patterns と排他）
 events           = ["create", "modify"]  # create / modify / delete / rename
 
 # ── ルール別ログ（省略可）──────────────────────────────────────────────────
@@ -122,6 +127,52 @@ type        = "command"
 shell       = "powershell"               # cmd / powershell / pwsh
 command     = "Write-Host 'Backed up: {Name} -> {Destination}'"
 working_dir = ""
+```
+
+## フィルタ設定
+
+ファイル名・フォルダ名それぞれに包含・除外フィルタを設定できます。各カテゴリで **glob と regex は排他**（両方設定するとバリデーションエラー）。
+
+| | ファイル名 | フォルダ名 |
+|---|---|---|
+| **包含** | `patterns` / `regex` | `dir_patterns` / `dir_regex` |
+| **除外** | `exclude_patterns` / `exclude_regex` | `exclude_dir_patterns` / `exclude_dir_regex` |
+
+### フォルダフィルタの動作
+
+`dir_patterns` / `dir_regex` は、イベントパスを監視ルートからの相対パスに変換し、その**親ディレクトリ成分のいずれか**にマッチすれば通過します。
+
+```
+watch_path = C:\project、dir_patterns = ["src"] の場合:
+
+C:\project\src\main.rs          → 親: [src]             ✅ src にマッチ → 通過
+C:\project\lib\utils.rs         → 親: [lib]             ❌ マッチなし → 除外
+C:\project\packages\app\src\index.ts → 親: [packages, app, src]  ✅ src にマッチ → 通過
+C:\project\config.toml          → 親: []（なし）         ❌ マッチなし → 除外
+```
+
+> **注意**: 監視ルート直下のファイルはフォルダを経由しないため、`dir_patterns` / `dir_regex` が設定されていると常に除外されます。
+
+### 除外優先ルール
+
+包含フィルタと除外フィルタが同じフォルダ・ファイルにマッチする場合、**除外が優先**されます。
+
+```
+dir_patterns         = ["src"]
+exclude_dir_patterns = ["src"]
+
+→ src 配下のファイルは包含チェックを通過するが、その後の除外チェックで除外される
+→ 結果: 何も検知されない（設定の矛盾に注意）
+```
+
+実用的な組み合わせ例:
+
+```
+dir_patterns         = ["src"]           # src フォルダ配下のみ対象
+exclude_dir_patterns = ["node_modules"]  # ただし node_modules は除外
+
+→ src\components\Button.ts    ✅（src にマッチ、node_modules なし）
+→ src\node_modules\react\index.ts  ❌（node_modules が除外優先）
 ```
 
 ## アクションの種類
@@ -170,7 +221,8 @@ CSV の列順（1 行目はヘッダー、自動でスキップ）：
 
 ```
 rule_name, enabled, watch_path, recursive, target, include_hidden,
-patterns, regex, exclude_patterns, events,
+patterns, regex, exclude_patterns, exclude_regex,
+dir_patterns, dir_regex, exclude_dir_patterns, exclude_dir_regex, events,
 action_type, destination, overwrite, preserve_structure, verify_integrity,
 shell, command, program, args, working_dir, message
 ```
@@ -202,6 +254,11 @@ shell, command, program, args, working_dir, message
 
 ```
 2026-05-07 10:30:20 │ INFO    │                             │ cat-watcher 起動
+2026-05-07 10:30:20 │ INFO    │                             │ 監視ルール [csv-backup]  パス=C:\data\incoming  イベント=作成, 変更  サブフォルダ=あり
+2026-05-07 10:30:20 │ INFO    │                             │   包含ファイル: *.csv, *.xlsx
+2026-05-07 10:30:20 │ INFO    │                             │   除外ファイル: temp_*
+2026-05-07 10:30:20 │ INFO    │                             │   包含フォルダ: incoming, drop
+2026-05-07 10:30:20 │ INFO    │                             │   除外フォルダ: node_modules
 2026-05-07 10:30:20 │ MATCH   │ Create,Modify               │ C:\data\report.csv
 2026-05-07 10:30:20 │ ├1 log  │                             │ 
 2026-05-07 10:30:20 │ │   OK  │                             │ 検知: report.csv

--- a/cat-watcher/src/config.rs
+++ b/cat-watcher/src/config.rs
@@ -152,6 +152,16 @@ pub struct Watch {
     pub patterns: Option<Vec<String>>,
     pub regex: Option<String>,
     pub exclude_patterns: Vec<String>,
+    #[serde(default)]
+    pub exclude_regex: Option<String>,
+    #[serde(default)]
+    pub exclude_dir_patterns: Vec<String>,
+    #[serde(default)]
+    pub exclude_dir_regex: Option<String>,
+    #[serde(default)]
+    pub dir_patterns: Vec<String>,
+    #[serde(default)]
+    pub dir_regex: Option<String>,
     pub events: Vec<Event>,
 }
 
@@ -299,6 +309,48 @@ pub fn validate_rules_config(config: &RulesConfig) -> Result<(), AppError> {
 		for glob in &rule.watch.exclude_patterns {
 			if let Err(e) = Glob::new(glob) {
 				errors.push(format!("監視ルール名 {} の exclude_patterns に無効な glob があります '{}': {}", rule_id, glob, e));
+			}
+		}
+
+		if !rule.watch.exclude_patterns.is_empty() && rule.watch.exclude_regex.is_some() {
+			errors.push(format!("監視ルール名 {} の exclude_patterns と exclude_regex は片方のみ定義できます", rule_id));
+		}
+
+		if let Some(re_str) = &rule.watch.exclude_regex {
+			if let Err(e) = Regex::new(re_str) {
+				errors.push(format!("監視ルール名 {} の exclude_regex に無効な正規表現があります '{}': {}", rule_id, re_str, e));
+			}
+		}
+
+		if !rule.watch.exclude_dir_patterns.is_empty() && rule.watch.exclude_dir_regex.is_some() {
+			errors.push(format!("監視ルール名 {} の exclude_dir_patterns と exclude_dir_regex は片方のみ定義できます", rule_id));
+		}
+
+		for glob in &rule.watch.exclude_dir_patterns {
+			if let Err(e) = Glob::new(glob) {
+				errors.push(format!("監視ルール名 {} の exclude_dir_patterns に無効な glob があります '{}': {}", rule_id, glob, e));
+			}
+		}
+
+		if let Some(re_str) = &rule.watch.exclude_dir_regex {
+			if let Err(e) = Regex::new(re_str) {
+				errors.push(format!("監視ルール名 {} の exclude_dir_regex に無効な正規表現があります '{}': {}", rule_id, re_str, e));
+			}
+		}
+
+		if !rule.watch.dir_patterns.is_empty() && rule.watch.dir_regex.is_some() {
+			errors.push(format!("監視ルール名 {} の dir_patterns と dir_regex は片方のみ定義できます", rule_id));
+		}
+
+		for glob in &rule.watch.dir_patterns {
+			if let Err(e) = Glob::new(glob) {
+				errors.push(format!("監視ルール名 {} の dir_patterns に無効な glob があります '{}': {}", rule_id, glob, e));
+			}
+		}
+
+		if let Some(re_str) = &rule.watch.dir_regex {
+			if let Err(e) = Regex::new(re_str) {
+				errors.push(format!("監視ルール名 {} の dir_regex に無効な正規表現があります '{}': {}", rule_id, re_str, e));
 			}
 		}
 
@@ -1074,6 +1126,393 @@ mod tests {
 			include_hidden = false
 			patterns = ["*.csv"]
 			exclude_patterns = ["[bad"]
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_err());
+	}
+
+	// =========================================================
+	// exclude_regex / exclude_dir_patterns / exclude_dir_regex (#28)
+	// =========================================================
+
+	#[test]
+	fn test_validate_exclude_patterns_and_exclude_regex_both_set() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "both-exclude"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = ["*.tmp"]
+			exclude_regex = "^debug"
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_validate_exclude_regex_only_valid() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "exclude-regex-only"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			exclude_regex = "^debug_\\d+"
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_ok());
+	}
+
+	#[test]
+	fn test_validate_invalid_exclude_regex() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "bad-exclude-regex"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			exclude_regex = "(unclosed"
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_validate_exclude_dir_patterns_and_exclude_dir_regex_both_set() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "both-dir-exclude"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			exclude_dir_patterns = ["node_modules"]
+			exclude_dir_regex = "^\\."
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_validate_exclude_dir_patterns_valid() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "dir-patterns-ok"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			exclude_dir_patterns = ["node_modules", ".git"]
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_ok());
+	}
+
+	#[test]
+	fn test_validate_invalid_exclude_dir_glob() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "bad-dir-glob"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			exclude_dir_patterns = ["[bad"]
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_validate_invalid_exclude_dir_regex() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "bad-dir-regex"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			exclude_dir_regex = "(unclosed"
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_validate_exclude_dir_regex_valid() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "dir-regex-ok"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			exclude_dir_regex = "^\\."
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_ok());
+	}
+
+	// =========================================================
+	// dir_patterns / dir_regex (#28)
+	// =========================================================
+
+	#[test]
+	fn test_validate_dir_patterns_and_dir_regex_both_set() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "both-dir-include"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			dir_patterns = ["src"]
+			dir_regex = "^reports"
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_validate_dir_patterns_valid() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "dir-patterns-include-ok"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			dir_patterns = ["src", "reports"]
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_ok());
+	}
+
+	#[test]
+	fn test_validate_invalid_dir_glob() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "bad-dir-include-glob"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			dir_patterns = ["[bad"]
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_validate_dir_regex_valid() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "dir-regex-include-ok"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			dir_regex = "^reports_\\d+"
+			events = ["create"]
+
+			[[rules.actions]]
+			type = "command"
+			shell = "cmd"
+			command = "echo hi"
+			working_dir = ""
+		"#, sanitize_path(dir.path()));
+		let config: RulesConfig = toml::from_str(&toml_str).unwrap();
+		let result = validate_rules_config(&config);
+		assert!(result.is_ok());
+	}
+
+	#[test]
+	fn test_validate_invalid_dir_regex() {
+		let dir = tempdir().unwrap();
+		let toml_str = format!(r#"
+			[[rules]]
+			enabled = true
+			name = "bad-dir-regex-include"
+
+			[rules.watch]
+			path = "{}"
+			recursive = true
+			target = "file"
+			include_hidden = false
+			patterns = ["*.csv"]
+			exclude_patterns = []
+			dir_regex = "(unclosed"
 			events = ["create"]
 
 			[[rules.actions]]

--- a/cat-watcher/src/router.rs
+++ b/cat-watcher/src/router.rs
@@ -50,6 +50,11 @@ pub struct CompiledRule{
 	pub events: Vec<Event>,
 	pub glob_set: Option<GlobSet>,
 	pub exclude_glob_set: Option<GlobSet>,
+	pub exclude_regex: Option<Regex>,
+	pub exclude_dir_glob_set: Option<GlobSet>,
+	pub exclude_dir_regex: Option<Regex>,
+	pub dir_glob_set: Option<GlobSet>,
+	pub dir_regex: Option<Regex>,
 	pub regexes: Option<Regex>,
 	pub actions: Vec<ActionConfig>,
 	pub rule_logger: Option<Arc<Logger>>,
@@ -86,6 +91,44 @@ pub fn compile_rules(rules: &[Rule], global: &Global) -> Result<(Vec<CompiledRul
 		} else {
 			None
 		};
+
+		let exclude_regex = if let Some(re_str) = &rule.watch.exclude_regex {
+			Some(Regex::new(re_str).map_err(|e| AppError::Watch(e.to_string()))?)
+		} else {
+			None
+		};
+
+		let exclude_dir_glob_set = if !rule.watch.exclude_dir_patterns.is_empty() {
+			let mut builder = GlobSetBuilder::new();
+			for p in &rule.watch.exclude_dir_patterns {
+				builder.add(Glob::new(p).map_err(|e| AppError::Watch(e.to_string()))?);
+			}
+			Some(builder.build().map_err(|e| AppError::Watch(e.to_string()))?)
+		} else {
+			None
+		};
+
+		let exclude_dir_regex = if let Some(re_str) = &rule.watch.exclude_dir_regex {
+			Some(Regex::new(re_str).map_err(|e| AppError::Watch(e.to_string()))?)
+		} else {
+			None
+		};
+
+		let dir_glob_set = if !rule.watch.dir_patterns.is_empty() {
+			let mut builder = GlobSetBuilder::new();
+			for p in &rule.watch.dir_patterns {
+				builder.add(Glob::new(p).map_err(|e| AppError::Watch(e.to_string()))?);
+			}
+			Some(builder.build().map_err(|e| AppError::Watch(e.to_string()))?)
+		} else {
+			None
+		};
+
+		let dir_regex = if let Some(re_str) = &rule.watch.dir_regex {
+			Some(Regex::new(re_str).map_err(|e| AppError::Watch(e.to_string()))?)
+		} else {
+			None
+		};
 		
 		let rule_logger = if let Some(rule_log) = &rule.log {
 			if rule_log.enabled {
@@ -117,6 +160,11 @@ pub fn compile_rules(rules: &[Rule], global: &Global) -> Result<(Vec<CompiledRul
 			events: rule.watch.events.clone(),
 			glob_set,
 			exclude_glob_set,
+			exclude_regex,
+			exclude_dir_glob_set,
+			exclude_dir_regex,
+			dir_glob_set,
+			dir_regex,
 			regexes,
 			actions: rule.actions.clone(),
 			rule_logger,
@@ -142,12 +190,7 @@ fn evaluate_rule(
         if path.parent() != Some(watch_path) { return false; }
     }
 
-    let file_name = match path.file_name().and_then(|n| n.to_str()) {
-		Some(name) => name,
-		None => return false, // ファイル名が UTF-8 でない場合はルール不適用
-	};
-
-    if !matches_pattern(&file_name, rule) { return false; }
+    if !matches_pattern(path, rule) { return false; }
     if !matches_events(detected_events, &rule.events) { return false; }
 
     true
@@ -182,8 +225,13 @@ fn matches_hidden(_path: &Path, _include_hidden: bool) -> bool {
     true  // 今は常に通過
 }
 
-/// patterns / exclude_patterns / regex マッチ
-fn matches_pattern(file_name: &str, rule: &CompiledRule) -> bool{
+/// patterns / exclude_patterns / regex / exclude_dir_* マッチ
+fn matches_pattern(path: &Path, rule: &CompiledRule) -> bool{
+	let file_name = match path.file_name().and_then(|n| n.to_str()) {
+		Some(name) => name,
+		None => return false,
+	};
+
 	if let Some(glob_set) = &rule.glob_set {
 		if !glob_set.is_match(file_name) {
 			return false;
@@ -196,9 +244,59 @@ fn matches_pattern(file_name: &str, rule: &CompiledRule) -> bool{
 		}
 	}
 
+	if let Some(exclude_regex) = &rule.exclude_regex {
+		if exclude_regex.is_match(file_name) {
+			return false;
+		}
+	}
+
 	if let Some(regexes) = &rule.regexes {
 		if !regexes.is_match(file_name) {
 			return false;
+		}
+	}
+
+	// ディレクトリ名包含: watch_path からの相対パスの親コンポーネントの少なくとも1つがマッチすること
+	if rule.dir_glob_set.is_some() || rule.dir_regex.is_some() {
+		let watch_root = Path::new(&rule.watch_path);
+		if let Ok(rel) = path.strip_prefix(watch_root) {
+			let rel_parent = rel.parent().unwrap_or(Path::new(""));
+			let matched = rel_parent.components().any(|component| {
+				if let std::path::Component::Normal(os_name) = component {
+					if let Some(dir_name) = os_name.to_str() {
+						if let Some(gs) = &rule.dir_glob_set {
+							if gs.is_match(dir_name) { return true; }
+						}
+						if let Some(re) = &rule.dir_regex {
+							if re.is_match(dir_name) { return true; }
+						}
+					}
+				}
+				false
+			});
+			if !matched { return false; }
+		} else {
+			return false;
+		}
+	}
+
+	// ディレクトリ名除外: watch_path からの相対パスの各ディレクトリコンポーネントを評価
+	if rule.exclude_dir_glob_set.is_some() || rule.exclude_dir_regex.is_some() {
+		let watch_root = Path::new(&rule.watch_path);
+		if let Ok(rel) = path.strip_prefix(watch_root) {
+			let rel_parent = rel.parent().unwrap_or(Path::new(""));
+			for component in rel_parent.components() {
+				if let std::path::Component::Normal(os_name) = component {
+					if let Some(dir_name) = os_name.to_str() {
+						if let Some(gs) = &rule.exclude_dir_glob_set {
+							if gs.is_match(dir_name) { return false; }
+						}
+						if let Some(re) = &rule.exclude_dir_regex {
+							if re.is_match(dir_name) { return false; }
+						}
+					}
+				}
+			}
 		}
 	}
 
@@ -342,6 +440,11 @@ mod tests {
             events: vec![Event::Create],
             glob_set,
             exclude_glob_set: None,
+            exclude_regex: None,
+            exclude_dir_glob_set: None,
+            exclude_dir_regex: None,
+            dir_glob_set: None,
+            dir_regex: None,
             regexes: None,
             actions: vec![],
             rule_logger: None,
@@ -507,5 +610,245 @@ mod tests {
         assert!(!matches_target(path, &WatchTarget::Directory, None));
         // target=both は通る
         assert!(matches_target(path, &WatchTarget::Both, None));
+    }
+
+    // -----------------------------------------------------------------
+    // exclude_regex: ファイル名正規表現除外 (#28)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_exclude_regex_excludes_matching_file() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("debug_001.log");
+        std::fs::write(&file, "").unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), false, None);
+        rule.exclude_regex = Some(Regex::new(r"^debug_\d+").unwrap());
+        let events = create_events(Event::Create);
+
+        assert!(!evaluate_rule(&file, &events, None, &rule));
+    }
+
+    #[test]
+    fn test_exclude_regex_passes_non_matching_file() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("report_001.log");
+        std::fs::write(&file, "").unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), false, None);
+        rule.exclude_regex = Some(Regex::new(r"^debug_\d+").unwrap());
+        let events = create_events(Event::Create);
+
+        assert!(evaluate_rule(&file, &events, None, &rule));
+    }
+
+    // -----------------------------------------------------------------
+    // exclude_dir_patterns: フォルダ名 glob 除外 (#28)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_exclude_dir_patterns_excludes_file_in_matching_dir() {
+        let dir = TempDir::new().unwrap();
+        let node_modules = dir.path().join("node_modules");
+        std::fs::create_dir(&node_modules).unwrap();
+        let file = node_modules.join("index.js");
+        std::fs::write(&file, "").unwrap();
+
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("node_modules").unwrap());
+        let gs = builder.build().unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.exclude_dir_glob_set = Some(gs);
+        let events = create_events(Event::Create);
+
+        assert!(!evaluate_rule(&file, &events, None, &rule));
+    }
+
+    #[test]
+    fn test_exclude_dir_patterns_passes_file_in_non_matching_dir() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+        let file = src.join("main.rs");
+        std::fs::write(&file, "").unwrap();
+
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("node_modules").unwrap());
+        let gs = builder.build().unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.exclude_dir_glob_set = Some(gs);
+        let events = create_events(Event::Create);
+
+        assert!(evaluate_rule(&file, &events, None, &rule));
+    }
+
+    #[test]
+    fn test_exclude_dir_patterns_nested_dir_excluded() {
+        let dir = TempDir::new().unwrap();
+        let parent = dir.path().join("packages");
+        let node_modules = parent.join("node_modules");
+        std::fs::create_dir_all(&node_modules).unwrap();
+        let file = node_modules.join("dep.js");
+        std::fs::write(&file, "").unwrap();
+
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("node_modules").unwrap());
+        let gs = builder.build().unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.exclude_dir_glob_set = Some(gs);
+        let events = create_events(Event::Create);
+
+        assert!(!evaluate_rule(&file, &events, None, &rule));
+    }
+
+    // -----------------------------------------------------------------
+    // exclude_dir_regex: フォルダ名正規表現除外 (#28)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_exclude_dir_regex_excludes_file_in_matching_dir() {
+        let dir = TempDir::new().unwrap();
+        let hidden = dir.path().join(".cache");
+        std::fs::create_dir(&hidden).unwrap();
+        let file = hidden.join("data.bin");
+        std::fs::write(&file, "").unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.exclude_dir_regex = Some(Regex::new(r"^\.").unwrap());
+        let events = create_events(Event::Create);
+
+        assert!(!evaluate_rule(&file, &events, None, &rule));
+    }
+
+    #[test]
+    fn test_exclude_dir_regex_passes_file_in_non_matching_dir() {
+        let dir = TempDir::new().unwrap();
+        let visible = dir.path().join("data");
+        std::fs::create_dir(&visible).unwrap();
+        let file = visible.join("report.csv");
+        std::fs::write(&file, "").unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.exclude_dir_regex = Some(Regex::new(r"^\.").unwrap());
+        let events = create_events(Event::Create);
+
+        assert!(evaluate_rule(&file, &events, None, &rule));
+    }
+
+    // -----------------------------------------------------------------
+    // dir_patterns: フォルダ名 glob 包含 (#28)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_dir_patterns_includes_file_in_matching_dir() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+        let file = src.join("main.rs");
+        std::fs::write(&file, "").unwrap();
+
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("src").unwrap());
+        let gs = builder.build().unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.dir_glob_set = Some(gs);
+        let events = create_events(Event::Create);
+
+        assert!(evaluate_rule(&file, &events, None, &rule));
+    }
+
+    #[test]
+    fn test_dir_patterns_excludes_file_in_non_matching_dir() {
+        let dir = TempDir::new().unwrap();
+        let lib = dir.path().join("lib");
+        std::fs::create_dir(&lib).unwrap();
+        let file = lib.join("utils.rs");
+        std::fs::write(&file, "").unwrap();
+
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("src").unwrap());
+        let gs = builder.build().unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.dir_glob_set = Some(gs);
+        let events = create_events(Event::Create);
+
+        assert!(!evaluate_rule(&file, &events, None, &rule));
+    }
+
+    #[test]
+    fn test_dir_patterns_direct_child_not_matched() {
+        // watch 直下のファイルはディレクトリコンポーネントが存在しないためマッチしない
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("root.csv");
+        std::fs::write(&file, "").unwrap();
+
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("src").unwrap());
+        let gs = builder.build().unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), false, None);
+        rule.dir_glob_set = Some(gs);
+        let events = create_events(Event::Create);
+
+        assert!(!evaluate_rule(&file, &events, None, &rule));
+    }
+
+    #[test]
+    fn test_dir_patterns_nested_dir_matched() {
+        // 深いネストでも途中にマッチするフォルダがあれば通る
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("packages").join("src").join("components");
+        std::fs::create_dir_all(&nested).unwrap();
+        let file = nested.join("button.tsx");
+        std::fs::write(&file, "").unwrap();
+
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("src").unwrap());
+        let gs = builder.build().unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.dir_glob_set = Some(gs);
+        let events = create_events(Event::Create);
+
+        assert!(evaluate_rule(&file, &events, None, &rule));
+    }
+
+    // -----------------------------------------------------------------
+    // dir_regex: フォルダ名正規表現包含 (#28)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_dir_regex_includes_file_in_matching_dir() {
+        let dir = TempDir::new().unwrap();
+        let reports = dir.path().join("reports_2024");
+        std::fs::create_dir(&reports).unwrap();
+        let file = reports.join("data.csv");
+        std::fs::write(&file, "").unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.dir_regex = Some(Regex::new(r"^reports_\d+$").unwrap());
+        let events = create_events(Event::Create);
+
+        assert!(evaluate_rule(&file, &events, None, &rule));
+    }
+
+    #[test]
+    fn test_dir_regex_excludes_file_in_non_matching_dir() {
+        let dir = TempDir::new().unwrap();
+        let other = dir.path().join("archives");
+        std::fs::create_dir(&other).unwrap();
+        let file = other.join("data.csv");
+        std::fs::write(&file, "").unwrap();
+
+        let mut rule = make_rule(dir.path().to_str().unwrap(), true, None);
+        rule.dir_regex = Some(Regex::new(r"^reports_\d+$").unwrap());
+        let events = create_events(Event::Create);
+
+        assert!(!evaluate_rule(&file, &events, None, &rule));
     }
 }

--- a/cat-watcher/src/watcher.rs
+++ b/cat-watcher/src/watcher.rs
@@ -50,14 +50,6 @@ pub async fn start_watching(
             RecursiveMode::NonRecursive
         };
 
-        let pattern_str = if let Some(pats) = &rule.watch.patterns {
-            pats.join(", ")
-        } else if let Some(re) = &rule.watch.regex {
-            format!("regex: {re}")
-        } else {
-            "*".to_string()
-        };
-
         let events_str = rule
             .watch
             .events
@@ -74,13 +66,40 @@ pub async fn start_watching(
         let recursive_str = if rule.watch.recursive { "あり" } else { "なし" };
 
         log.info(format!(
-            "監視ルール [{}]  パス={}  パターン={}  イベント={}  サブフォルダ={}",
+            "監視ルール [{}]  パス={}  イベント={}  サブフォルダ={}",
             rule.name,
             canonical_display,
-            pattern_str,
             events_str,
             recursive_str,
         ));
+
+        // 包含ファイルフィルタ
+        if let Some(pats) = &rule.watch.patterns {
+            log.info(format!("  包含ファイル: {}", pats.join(", ")));
+        } else if let Some(re) = &rule.watch.regex {
+            log.info(format!("  包含ファイル: regex: {re}"));
+        }
+
+        // 除外ファイルフィルタ
+        if !rule.watch.exclude_patterns.is_empty() {
+            log.info(format!("  除外ファイル: {}", rule.watch.exclude_patterns.join(", ")));
+        } else if let Some(re) = &rule.watch.exclude_regex {
+            log.info(format!("  除外ファイル: regex: {re}"));
+        }
+
+        // 包含フォルダフィルタ
+        if !rule.watch.dir_patterns.is_empty() {
+            log.info(format!("  包含フォルダ: {}", rule.watch.dir_patterns.join(", ")));
+        } else if let Some(re) = &rule.watch.dir_regex {
+            log.info(format!("  包含フォルダ: regex: {re}"));
+        }
+
+        // 除外フォルダフィルタ
+        if !rule.watch.exclude_dir_patterns.is_empty() {
+            log.info(format!("  除外フォルダ: {}", rule.watch.exclude_dir_patterns.join(", ")));
+        } else if let Some(re) = &rule.watch.exclude_dir_regex {
+            log.info(format!("  除外フォルダ: regex: {re}"));
+        }
 
         watch_map
             .entry(path)


### PR DESCRIPTION
## 概要

イシュー #28 の実装。ファイル名・フォルダ名 × 包含・除外 × glob・regex の **2×2×2 対称設計** を完成させた。

| | ファイル名 | フォルダ名 |
|---|---|---|
| **包含** | `patterns` / `regex` ✅ (既存) | `dir_patterns` / `dir_regex` ✅ (新規) |
| **除外** | `exclude_patterns` / `exclude_regex` ✅ (新規) | `exclude_dir_patterns` / `exclude_dir_regex` ✅ (新規) |

各カテゴリで glob と regex は**排他**（両方設定するとバリデーションエラー）。

---

## 新しい設定フィールド

```toml
[rules.watch]
path = "/watch"
recursive = true
target = "file"
include_hidden = false
patterns = ["*.csv"]          # glob, ファイル名包含（既存）
# regex = "^report_\\d+"      # regex, ファイル名包含（既存・排他）

exclude_patterns = ["*.tmp"]  # glob, ファイル名除外（既存）
# exclude_regex = "^debug_"   # regex, ファイル名除外（新規・排他）

dir_patterns = ["src", "reports"]  # glob, フォルダ名包含（新規）
# dir_regex = "^reports_\\d+"      # regex, フォルダ名包含（新規・排他）

exclude_dir_patterns = ["node_modules", ".git"]  # glob, フォルダ名除外（新規）
# exclude_dir_regex = "^\\..*"                    # regex, フォルダ名除外（新規・排他）

events = ["create", "modify"]
```

---

## 起動ログ出力例

設定されているフィルタを起動時に詳細出力するよう `watcher.rs` を更新した。

```
2026-05-18 10:00:00 │ INFO    │                            │ 監視ルール [csv-watcher]  パス=/watch  イベント=作成, 変更  サブフォルダ=あり
2026-05-18 10:00:00 │ INFO    │                            │   包含ファイル: *.csv
2026-05-18 10:00:00 │ INFO    │                            │   除外ファイル: *.tmp
2026-05-18 10:00:00 │ INFO    │                            │   包含フォルダ: src, reports
2026-05-18 10:00:00 │ INFO    │                            │   除外フォルダ: node_modules, .git
```

未設定のフィールドは出力しない。

---

## 変更ファイル

- `cat-watcher/src/config.rs` — `Watch` struct に新フィールド追加、バリデーション追加、テスト追加
- `cat-watcher/src/router.rs` — `CompiledRule` に新フィールド追加、`compile_rules` 更新、`matches_pattern` にディレクトリ包含・除外ロジック追加、テスト追加
- `cat-watcher/src/watcher.rs` — 起動ログにフィルタ詳細出力を追加

## テスト

```
cargo test
# 152 tests passed (既存 126 + 新規 26)
```

## Test plan

- [ ] `cargo build` でコンパイルエラーなし
- [ ] `cargo test` で全 152 件通過
- [ ] `dir_patterns` を設定し、指定フォルダ配下のファイルのみ検知されることを確認
- [ ] `dir_regex` を設定し、正規表現マッチするフォルダ配下のみ検知されることを確認
- [ ] `exclude_regex` を設定し、正規表現マッチするファイルが除外されることを確認
- [ ] `exclude_dir_patterns` を設定し、指定フォルダ配下が除外されることを確認
- [ ] glob と regex を同時設定するとバリデーションエラーになることを確認
- [ ] 起動ログに設定フィルタが正しく出力されることを確認

https://claude.ai/code/session_01MkVrcdxrcq4ZZmexRhJHC9

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkVrcdxrcq4ZZmexRhJHC9)_