### PR TITLE
feat(windows): Windowsサービスとしてネイティブ起動できるよう対応

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -157,6 +163,7 @@ dependencies = [
  "toml 0.8.23",
  "unicode-width",
  "walkdir",
+ "windows-service",
  "winres",
 ]
 
@@ -497,7 +504,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -563,7 +570,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -639,7 +646,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -649,7 +656,7 @@ dependencies = [
 name = "notify"
 version = "8.2.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossbeam-channel",
  "flume",
  "fsevent-sys",
@@ -674,7 +681,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "serde",
 ]
 
@@ -708,7 +715,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -805,7 +812,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1209,11 +1216,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi-util"
@@ -1284,6 +1297,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-service"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9db37ecb5b13762d95468a2fc6009d4b2c62801243223aabd44fca13ad13c8"
+dependencies = [
+ "bitflags 1.3.2",
+ "widestring",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,6 +1341,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1345,6 +1393,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1357,6 +1411,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1366,6 +1426,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1393,6 +1459,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1402,6 +1474,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1417,6 +1495,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1426,6 +1510,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1521,7 +1611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - **リアルタイム監視**: 指定フォルダの create / modify / delete / rename を検知
 - **対称設計フィルタ**: ファイル名・フォルダ名 × 包含・除外 × glob・regex の 2×2×2 = 8 通りのフィルタを自由に組み合わせ可能
 - **5 種類のアクション**: log / copy / move / command（シェル経由）/ execute（プロセス直接起動）
-- **クロスプラットフォームシェル**: Windows は cmd / powershell / pwsh、Linux・macOS は bash / sh / pwsh に対応
+- **クロスプラットフォームシェル**: Windows は `cmd` / `powershell` / `pwsh`、Linux・macOS は `bash` / `sh` / `pwsh` に対応
 - **アクションチェーン**: 1 ルールに複数アクションを順次実行（直前のコピー先を `{Destination}` で参照可能）
 - **プレースホルダー**: 監視ファイルのパス・名前・日時などを宛先や引数に埋め込める
 - **整合性検証**: BLAKE3 ハッシュでコピー後のファイル一致を確認
@@ -19,7 +19,6 @@
 - **ログ出力先の個別制御**: コンソール・ファイルを個別に有効/無効、ログレベルも別々に指定可能
 - **テンプレート生成**: `--init global rules csv` のように複数のテンプレートを一括で出力できる
 - **ホームディレクトリ展開**: パス設定で `~` が使用可能（`~/logs` など）
-- **ログ CSV 形式**: ファイルログを CSV 出力するので `grep` や `awk` でフィルタリングが容易
 - **全件エラー報告**: 設定ファイルに複数の問題があっても、1 回の起動で全エラーをまとめて表示
 - **大文字小文字不区別**: 設定値は `create` / `Create` / `CREATE` のいずれでも動作
 - **CSV → TOML 変換**: Excel で書いたルールを TOML に変換する `--from-csv` モード
@@ -250,50 +249,27 @@ shell, command, program, args, working_dir, message
 
 ```
 ──────────────────────────────────────────────────────────────
-[2026-05-07 10:30:20] [MATCH]  パス=C:\data\report.csv | イベント=Create|Modify | ルール=csv-backup
+[2026-05-07 10:30:20] [MATCH]   ルール=csv-backup | パス=C:\data\report.csv | Create, Modify
 [2026-05-07 10:30:20] [ACTION]  (1/3) log
 [2026-05-07 10:30:20] [INFO]    検知: report.csv
 [2026-05-07 10:30:20] [ACTION]  (2/3) copy  C:\data\report.csv → D:\backup\20260507
 [2026-05-07 10:30:20] [OK]      コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
 [2026-05-07 10:30:20] [ACTION]  (3/3) command  shell=powershell  cmd=Write-Host 'Backed up: ...'
-[2026-05-07 10:30:20] [OK]      起動
+[2026-05-07 10:30:20] [OK]      コマンド完了
 ```
 
-**ファイル出力**（CSV 形式）
+**ファイル出力**（4列固定幅フォーマット）
 
 ```
-2026-05-07 10:30:20,INFO,cat-watcher 起動
-2026-05-07 10:30:20,INFO,監視ルール [csv-backup]  パス=C:\data\incoming  サブフォルダ=あり
-2026-05-07 10:30:20,MATCH,C:\data\report.csv,Create|Modify,csv-backup
-2026-05-07 10:30:20,ACTION,1/3,log,
-2026-05-07 10:30:20,SUCCESS,1/3,検知: report.csv
-2026-05-07 10:30:20,ACTION,2/3,copy,C:\data\report.csv → D:\backup\{Date}
-2026-05-07 10:30:20,SUCCESS,2/3,コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
-2026-05-07 10:30:20,ACTION,3/3,command,shell=powershell  cmd=Write-Host 'Backed up: ...'
-2026-05-07 10:30:20,SUCCESS,3/3,起動
+2026-05-07 10:30:20 │ INFO    │                             │ cat-watcher 起動
+2026-05-07 10:30:20 │ MATCH   │ Create,Modify               │ C:\data\report.csv
+2026-05-07 10:30:20 │ ├1 log  │                             │
+2026-05-07 10:30:20 │ │   OK  │                             │ 検知: report.csv
+2026-05-07 10:30:20 │ ├2 cop  │                             │ C:\data\report.csv → D:\backup\{Date}
+2026-05-07 10:30:20 │ │   OK  │                             │ コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
+2026-05-07 10:30:20 │ └3 cmd  │                             │ shell=powershell  cmd=Write-Host 'Backed up: ...'
+2026-05-07 10:30:20 │    OK   │                             │ 起動
 ```
-
-CSV 形式なので `grep` / `awk` / Excel での集計が容易です。
-
-```bash
-# MATCH レコードのみ抽出
-grep ",MATCH," cat-watcher.log
-
-# MATCH のパス一覧（3列目）
-grep ",MATCH," cat-watcher.log | cut -d, -f3
-
-# ルール名でフィルタ（5列目）
-grep ",MATCH," cat-watcher.log | awk -F, '$5=="csv-backup"'
-```
-
-各カラムの意味：
-
-| レコード種別 | フォーマット |
-|---|---|
-| MATCH | `timestamp,MATCH,path,events,rule_name` |
-| ACTION | `timestamp,ACTION,index/total,type,detail` |
-| SUCCESS | `timestamp,SUCCESS,index/total,message` |
-| INFO / WARN / ERROR | `timestamp,LEVEL,message` |
 
 `log_to_console = false` でターミナル出力を、`log_to_file = false` でファイル出力を無効にできます。`terminal_log_level` / `file_log_level` でそれぞれのログレベルを個別に設定することもできます。
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **リアルタイム監視**: 指定フォルダの create / modify / delete / rename を検知
 - **対称設計フィルタ**: ファイル名・フォルダ名 × 包含・除外 × glob・regex の 2×2×2 = 8 通りのフィルタを自由に組み合わせ可能
 - **5 種類のアクション**: log / copy / move / command（シェル経由）/ execute（プロセス直接起動）
+- **クロスプラットフォームシェル**: Windows は cmd / powershell / pwsh、Linux・macOS は bash / sh / pwsh に対応
 - **アクションチェーン**: 1 ルールに複数アクションを順次実行（直前のコピー先を `{Destination}` で参照可能）
 - **プレースホルダー**: 監視ファイルのパス・名前・日時などを宛先や引数に埋め込める
 - **整合性検証**: BLAKE3 ハッシュでコピー後のファイル一致を確認
@@ -16,7 +17,9 @@
 - **ログローテーション**: 日次でログファイルを切り替え（`log_rotation = "never"` で固定ファイルにも対応）
 - **ルール別ログ**: ルールごとに独立したログファイルへ出力（`[rules.log]` セクションで設定）
 - **ログ出力先の個別制御**: コンソール・ファイルを個別に有効/無効、ログレベルも別々に指定可能
-- **テンプレート生成**: `--init` で設定ファイルのひな形をすぐに出力できる
+- **テンプレート生成**: `--init global rules csv` のように複数のテンプレートを一括で出力できる
+- **ホームディレクトリ展開**: パス設定で `~` が使用可能（`~/logs` など）
+- **ログ CSV 形式**: ファイルログを CSV 出力するので `grep` や `awk` でフィルタリングが容易
 - **全件エラー報告**: 設定ファイルに複数の問題があっても、1 回の起動で全エラーをまとめて表示
 - **大文字小文字不区別**: 設定値は `create` / `Create` / `CREATE` のいずれでも動作
 - **CSV → TOML 変換**: Excel で書いたルールを TOML に変換する `--from-csv` モード
@@ -40,11 +43,15 @@ cargo build --release --manifest-path cat-watcher/Cargo.toml
 
 ```bash
 # 設定ファイルのテンプレートを生成（まずここから）
-cat-watcher --init global
-cat-watcher --init rules
-cat-watcher --init csv
+cat-watcher --init global          # global.toml を生成
+cat-watcher --init rules           # rules.toml を生成
+cat-watcher --init csv             # rules.csv を生成
 
-# 出力先ファイルを明示する場合
+# 複数テンプレートを一括生成
+cat-watcher --init global rules
+cat-watcher --init global rules csv
+
+# 出力先ファイルを明示する場合（--init が1種類のときのみ使用可）
 cat-watcher --init global --output config\global.toml
 cat-watcher --init rules  --output config\rules.toml
 
@@ -66,7 +73,7 @@ cat-watcher --from-csv rules.csv --output rules.toml
 ```toml
 [global]
 log_level         = "info"                    # trace / debug / info / warn / error
-log_dir           = "C:\\logs"
+log_dir           = "C:\\logs"               # ~ によるホームディレクトリ展開も可（例: ~/logs）
 log_file_name     = "cat-watcher_{Date}.log"  # {Date} / {DateTime} を埋め込み可
 log_rotation      = "daily"                   # daily / never
 retry_count       = 3
@@ -89,7 +96,7 @@ enabled = true
 name    = "csv-backup"
 
 [rules.watch]
-path             = "C:\\data\\incoming"
+path             = "C:\\data\\incoming"      # ~ によるホームディレクトリ展開も可（例: ~/data）
 recursive        = true
 target           = "file"                # file / directory / both
 include_hidden   = false
@@ -125,7 +132,8 @@ verify_integrity   = true                # BLAKE3 でコピー検証
 
 [[rules.actions]]
 type        = "command"
-shell       = "powershell"               # cmd / powershell / pwsh
+shell       = "powershell"               # Windows: cmd / powershell / pwsh
+                                         # Linux・macOS: bash / sh / pwsh
 command     = "Write-Host 'Backed up: {Name} -> {Destination}'"
 working_dir = ""
 ```
@@ -183,7 +191,7 @@ exclude_dir_patterns = ["node_modules"]  # ただし node_modules は除外
 | `log`     | イベントをログファイルに記録するだけ（コマンド実行なし） | `message` |
 | `copy`    | ファイル / ディレクトリをコピー | `destination`, `overwrite`, `preserve_structure`, `verify_integrity` |
 | `move`    | ファイル / ディレクトリを移動（異ボリュームは copy + delete にフォールバック） | `destination`, `overwrite`, `preserve_structure`, `verify_integrity` |
-| `command` | シェル経由でコマンド実行 | `shell` (`cmd` / `powershell` / `pwsh`), `command`, `working_dir` |
+| `command` | シェル経由でコマンド実行 | `shell`（Windows: `cmd` / `powershell` / `pwsh`、Linux: `bash` / `sh` / `pwsh`）, `command`, `working_dir` |
 | `execute` | プログラムを直接起動 | `program`, `args`, `working_dir` |
 
 ## プレースホルダー
@@ -242,34 +250,88 @@ shell, command, program, args, working_dir, message
 
 ```
 ──────────────────────────────────────────────────────────────
-[2026-05-07 10:30:20] [MATCH]   ルール=csv-backup | パス=C:\data\report.csv | Create, Modify
+[2026-05-07 10:30:20] [MATCH]  パス=C:\data\report.csv | イベント=Create|Modify | ルール=csv-backup
 [2026-05-07 10:30:20] [ACTION]  (1/3) log
 [2026-05-07 10:30:20] [INFO]    検知: report.csv
 [2026-05-07 10:30:20] [ACTION]  (2/3) copy  C:\data\report.csv → D:\backup\20260507
 [2026-05-07 10:30:20] [OK]      コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
 [2026-05-07 10:30:20] [ACTION]  (3/3) command  shell=powershell  cmd=Write-Host 'Backed up: ...'
-[2026-05-07 10:30:20] [OK]      コマンド完了
+[2026-05-07 10:30:20] [OK]      起動
 ```
 
-**ファイル出力**（4列固定幅フォーマット）
+**ファイル出力**（CSV 形式）
 
 ```
-2026-05-07 10:30:20 │ INFO    │                             │ cat-watcher 起動
-2026-05-07 10:30:20 │ INFO    │                             │ 監視ルール [csv-backup]  パス=C:\data\incoming  イベント=作成, 変更  サブフォルダ=あり
-2026-05-07 10:30:20 │ INFO    │                             │   包含ファイル: *.csv, *.xlsx
-2026-05-07 10:30:20 │ INFO    │                             │   除外ファイル: temp_*
-2026-05-07 10:30:20 │ INFO    │                             │   包含フォルダ: incoming, drop
-2026-05-07 10:30:20 │ INFO    │                             │   除外フォルダ: node_modules
-2026-05-07 10:30:20 │ MATCH   │ Create,Modify               │ C:\data\report.csv
-2026-05-07 10:30:20 │ ├1 log  │                             │ 
-2026-05-07 10:30:20 │ │   OK  │                             │ 検知: report.csv
-2026-05-07 10:30:20 │ ├2 cop  │                             │ C:\data\report.csv → D:\backup\{Date}
-2026-05-07 10:30:20 │ │   OK  │                             │ コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
-2026-05-07 10:30:20 │ └3 cmd  │                             │ shell=powershell  cmd=Write-Host 'Backed up: ...'
-2026-05-07 10:30:20 │    OK   │                             │ 起動
+2026-05-07 10:30:20,INFO,cat-watcher 起動
+2026-05-07 10:30:20,INFO,監視ルール [csv-backup]  パス=C:\data\incoming  サブフォルダ=あり
+2026-05-07 10:30:20,MATCH,C:\data\report.csv,Create|Modify,csv-backup
+2026-05-07 10:30:20,ACTION,1/3,log,
+2026-05-07 10:30:20,SUCCESS,1/3,検知: report.csv
+2026-05-07 10:30:20,ACTION,2/3,copy,C:\data\report.csv → D:\backup\{Date}
+2026-05-07 10:30:20,SUCCESS,2/3,コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
+2026-05-07 10:30:20,ACTION,3/3,command,shell=powershell  cmd=Write-Host 'Backed up: ...'
+2026-05-07 10:30:20,SUCCESS,3/3,起動
 ```
+
+CSV 形式なので `grep` / `awk` / Excel での集計が容易です。
+
+```bash
+# MATCH レコードのみ抽出
+grep ",MATCH," cat-watcher.log
+
+# MATCH のパス一覧（3列目）
+grep ",MATCH," cat-watcher.log | cut -d, -f3
+
+# ルール名でフィルタ（5列目）
+grep ",MATCH," cat-watcher.log | awk -F, '$5=="csv-backup"'
+```
+
+各カラムの意味：
+
+| レコード種別 | フォーマット |
+|---|---|
+| MATCH | `timestamp,MATCH,path,events,rule_name` |
+| ACTION | `timestamp,ACTION,index/total,type,detail` |
+| SUCCESS | `timestamp,SUCCESS,index/total,message` |
+| INFO / WARN / ERROR | `timestamp,LEVEL,message` |
 
 `log_to_console = false` でターミナル出力を、`log_to_file = false` でファイル出力を無効にできます。`terminal_log_level` / `file_log_level` でそれぞれのログレベルを個別に設定することもできます。
+
+## Windows サービスとして登録する
+
+`cat-watcher.exe` は Windows サービスとして登録・常駐できます。OS 起動時に自動で監視を開始したい場合に使います。
+
+### 登録手順
+
+管理者権限のコマンドプロンプト（または PowerShell）で実行してください。
+
+```cmd
+:: サービスを登録（--global / --rules のパスは絶対パスで指定）
+sc create cat-watcher ^
+  binPath= "C:\tools\cat-watcher.exe --global C:\tools\global.toml --rules C:\tools\rules.toml" ^
+  start= auto ^
+  DisplayName= "cat-watcher"
+
+:: サービスを開始
+sc start cat-watcher
+
+:: サービスの状態を確認
+sc query cat-watcher
+```
+
+### 停止・削除
+
+```cmd
+sc stop cat-watcher
+sc delete cat-watcher
+```
+
+### 注意事項
+
+- `binPath=` の後のパスはすべて **絶対パス** で指定してください（`~` や相対パスは SCM が解釈できません）
+- サービスモードでは **コンソール出力は自動で無効** になり、ファイルログのみ出力されます
+- `global.toml` の `log_to_file = true` と `log_dir` を正しく設定しておく必要があります
+- 通常の CLI 起動（`cat-watcher -g ... -r ...`）の動作は変わりません
 
 ## 開発
 

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -18,6 +18,9 @@ walkdir = "2"
 colored = "2"
 unicode-width = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows-service = "0.6"
+
 [build-dependencies]
 winres = "0.1"
 

--- a/cat-watcher/src/actions/command.rs
+++ b/cat-watcher/src/actions/command.rs
@@ -63,12 +63,33 @@ fn build_shell_command(
             Ok(c)
         }
         "pwsh" => {
-            let mut c = tokio::process::Command::new("pwsh.exe");
+            #[cfg(windows)]
+            let bin = "pwsh.exe";
+            #[cfg(not(windows))]
+            let bin = "pwsh";
+            let mut c = tokio::process::Command::new(bin);
             c.args(["-NoProfile", "-Command", expanded]);
             Ok(c)
         }
+        #[cfg(not(windows))]
+        "bash" => {
+            let mut c = tokio::process::Command::new("bash");
+            c.args(["-c", expanded]);
+            Ok(c)
+        }
+        #[cfg(not(windows))]
+        "sh" => {
+            let mut c = tokio::process::Command::new("sh");
+            c.args(["-c", expanded]);
+            Ok(c)
+        }
         other => Err(AppError::Action(format!(
-            "command: 不明なシェル '{other}'。cmd / powershell / pwsh のいずれかを指定してください"
+            "command: 不明なシェル '{other}'。{} のいずれかを指定してください",
+            if cfg!(windows) {
+                "cmd / powershell / pwsh"
+            } else {
+                "bash / sh / pwsh"
+            }
         ))),
     }
 }
@@ -140,11 +161,35 @@ mod tests {
         let src = dir.path().join("a.txt");
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
-        let action = make_action("bash", "echo hi", "");
+        let action = make_action("zsh", "echo hi", "");
         let global = make_global();
         let result = execute(&action, &ctx, &global, make_logger(), (1, 1)).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("不明なシェル"));
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn bash_spawns_successfully() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("a.txt");
+        std::fs::write(&src, b"x").unwrap();
+        let ctx = make_ctx(&src, dir.path());
+        let action = make_action("bash", "echo hello", "");
+        let global = make_global();
+        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn sh_spawns_successfully() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("a.txt");
+        std::fs::write(&src, b"x").unwrap();
+        let ctx = make_ctx(&src, dir.path());
+        let action = make_action("sh", "echo hello", "");
+        let global = make_global();
+        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -200,6 +245,6 @@ mod tests {
 
     #[test]
     fn build_shell_command_unknown() {
-        assert!(build_shell_command("bash", "echo hi").is_err());
+        assert!(build_shell_command("zsh", "echo hi").is_err());
     }
 }

--- a/cat-watcher/src/config.rs
+++ b/cat-watcher/src/config.rs
@@ -191,17 +191,39 @@ pub struct ActionConfig {
     pub message: Option<String>,
 }
 
+fn expand_tilde(s: &str) -> String {
+	if s == "~" || s.starts_with("~/") || s.starts_with("~\\") {
+		let home = std::env::var_os("HOME")
+			.or_else(|| std::env::var_os("USERPROFILE"))
+			.map(|h| h.to_string_lossy().into_owned())
+			.unwrap_or_default();
+		return format!("{}{}", home, &s[1..]);
+	}
+	s.to_string()
+}
+
 pub fn load_global_config(path: &Path) -> Result<GlobalConfig, AppError> {
 	let content = std::fs::read_to_string(path)?;
-	let config: GlobalConfig = toml::from_str(&content)
+	let mut config: GlobalConfig = toml::from_str(&content)
 							.map_err(|e| AppError::TomlParse(e.to_string()))?;
+	config.global.log_dir = expand_tilde(&config.global.log_dir);
 	Ok(config)
 }
 
 pub fn load_rules_config(path: &Path) -> Result<RulesConfig, AppError> {
 	let content = std::fs::read_to_string(path)?;
-	let config: RulesConfig = toml::from_str(&content)
+	let mut config: RulesConfig = toml::from_str(&content)
 							.map_err(|e| AppError::TomlParse(e.to_string()))?;
+	for rule in &mut config.rules {
+		rule.watch.path = expand_tilde(&rule.watch.path);
+		for action in &mut rule.actions {
+			action.destination = action.destination.as_deref().map(expand_tilde);
+			action.working_dir = action.working_dir.as_deref().map(expand_tilde);
+		}
+		if let Some(log) = &mut rule.log {
+			log.log_dir = log.log_dir.as_deref().map(expand_tilde);
+		}
+	}
 	Ok(config)
 }
 

--- a/cat-watcher/src/logger.rs
+++ b/cat-watcher/src/logger.rs
@@ -13,14 +13,12 @@ use unicode_width::UnicodeWidthStr;
 
 const SEPARATOR: &str = "──────────────────────────────────────────────────────────────";
 
-const FILE_LEVEL_WIDTH: usize = 7;
-const FILE_EVENTS_WIDTH: usize = 27;
-
 /// 表示列幅 (East Asian Width, CJK モード) で左寄せパディングする。
 /// Rust 標準の `format!("{:<width$}")` は char 数で揃えるため、
 /// '└' '│' '├' '─' などの罫線記号で表示時に列幅がズレる。
 /// 本プロジェクトは日本語ロケール (CJK) を主用途とするため、
 /// East Asian Ambiguous 文字を 2 列幅として扱う `width_cjk()` を使う。
+#[allow(dead_code)]
 fn pad_left_display(s: &str, total_cols: usize) -> String {
     let w = UnicodeWidthStr::width_cjk(s);
     if w >= total_cols {
@@ -196,79 +194,28 @@ async fn open_log_file(path: &PathBuf) -> Option<tokio::fs::File> {
     }
 }
 
-/// アクション種別を最大4文字の短縮名に変換する。
-fn action_type_short(action_type: &str) -> &str {
-    match action_type {
-        "copy" => "copy",
-        "move" => "move",
-        "command" => "cmd",
-        "execute" => "exec",
-        "log" => "log",
-        other => {
-            if other.len() <= 4 { other } else { &other[..4] }
-        }
-    }
-}
-
-/// ファイルログ用 level カラム文字列（FILE_LEVEL_WIDTH **列** 幅）を生成する。
-/// 全角記号 ('└' '├' '│') を含むため、char 数ではなく表示列幅でパディングする。
-fn file_level_col(entry: &LogEntry) -> String {
+/// ファイルログ用 CSV 1行を生成する。
+/// フォーマット:
+///   MATCH:     timestamp,MATCH,path,events,rule_name
+///   ACTION:    timestamp,ACTION,index/total,type,detail
+///   SUCCESS:   timestamp,SUCCESS,msg
+///   INFO/WARN/ERROR: timestamp,LEVEL,msg
+fn format_csv_line(ts: &str, entry: &LogEntry) -> String {
     match entry {
-        LogEntry::Match { .. } => pad_left_display("MATCH", FILE_LEVEL_WIDTH),
-        LogEntry::Action { index, total, action_type, .. } => {
-            let tree = if *index == *total { '└' } else { '├' };
-            let short = action_type_short(action_type);
-            let index_str = index.to_string();
-            // tree ('└'/'├' は CJK で 列幅 2) + index + space(1) + type で
-            // FILE_LEVEL_WIDTH 列に収める。type も CJK 列幅基準で切り詰める。
-            let used_cols = 2 + index_str.len() + 1;
-            let type_max_cols = FILE_LEVEL_WIDTH.saturating_sub(used_cols);
-            let mut type_part = String::new();
-            let mut used = 0usize;
-            for c in short.chars() {
-                let cw = UnicodeWidthStr::width_cjk(c.to_string().as_str());
-                if used + cw > type_max_cols { break; }
-                type_part.push(c);
-                used += cw;
-            }
-            let head = format!("{}{} {}", tree, index_str, type_part);
-            pad_left_display(&head, FILE_LEVEL_WIDTH)
+        LogEntry::Match { rule_name, path, events } => {
+            let ev = format_events(events);
+            format!("{ts},MATCH,{path},{ev},{rule_name}\n")
         }
-        LogEntry::ActionOk { index, total, .. } => {
-            if *index == *total {
-                // 最終ステップ完了: 継続パイプなし
-                pad_left_display("   OK", FILE_LEVEL_WIDTH)
-            } else {
-                // 中間ステップ完了: 継続パイプあり ('│' は列幅 2)
-                pad_left_display("│   OK", FILE_LEVEL_WIDTH)
-            }
+        LogEntry::Action { index, total, action_type, detail } => {
+            let detail = detail.replace('\n', r"\n");
+            format!("{ts},ACTION,{index}/{total},{action_type},{detail}\n")
         }
-        LogEntry::Info(_) => pad_left_display("INFO", FILE_LEVEL_WIDTH),
-        LogEntry::Warn(_) => pad_left_display("WARN", FILE_LEVEL_WIDTH),
-        LogEntry::Error(_) => pad_left_display("ERROR", FILE_LEVEL_WIDTH),
-        LogEntry::Shutdown => unreachable!(),
-    }
-}
-
-/// ファイルログ用 events カラム文字列（FILE_EVENTS_WIDTH **列** 幅）を生成する。
-/// MATCH エントリのみイベント名を出力し、それ以外は空白で埋める。
-fn file_events_col(entry: &LogEntry) -> String {
-    let s = match entry {
-        LogEntry::Match { events, .. } => format_events(events),
-        _ => String::new(),
-    };
-    pad_left_display(&s, FILE_EVENTS_WIDTH)
-}
-
-/// ファイルログ用 content カラムを生成する。
-fn file_content(entry: &LogEntry) -> String {
-    match entry {
-        LogEntry::Match { path, .. } => path.clone(),
-        LogEntry::Action { detail, .. } => detail.replace('\n', r"\n"),
-        LogEntry::ActionOk { msg, .. } => msg.clone(),
-        LogEntry::Info(msg) => msg.clone(),
-        LogEntry::Warn(msg) => msg.clone(),
-        LogEntry::Error(msg) => msg.clone(),
+        LogEntry::ActionOk { index, total, msg } => {
+            format!("{ts},SUCCESS,{index}/{total},{msg}\n")
+        }
+        LogEntry::Info(msg) => format!("{ts},INFO,{msg}\n"),
+        LogEntry::Warn(msg) => format!("{ts},WARN,{msg}\n"),
+        LogEntry::Error(msg) => format!("{ts},ERROR,{msg}\n"),
         LogEntry::Shutdown => unreachable!(),
     }
 }
@@ -306,25 +253,10 @@ async fn writer_task(
 
         let ts = now.format("%Y-%m-%d %H:%M:%S").to_string();
 
-        // ─── ファイルログ（4カラム固定幅フォーマット）───────────────────────
-        if log_to_file {
-            let file_line = match &entry {
-                LogEntry::Match { .. } | LogEntry::Action { .. } | LogEntry::ActionOk { .. }
-                | LogEntry::Info(_) | LogEntry::Warn(_) | LogEntry::Error(_) => {
-                    if !level_enabled_for_entry(&file_level, &entry) {
-                        String::new()
-                    } else {
-                        let lv = file_level_col(&entry);
-                        let ev = file_events_col(&entry);
-                        let ct = file_content(&entry);
-                        format!("{} │ {} │ {} │ {}\n", ts, lv, ev, ct)
-                    }
-                }
-                LogEntry::Shutdown => unreachable!(),
-            };
-            if !file_line.is_empty() {
-                write_file(&mut file, &file_line).await;
-            }
+        // ─── ファイルログ（CSV形式）────────────────────────────────────────
+        if log_to_file && level_enabled_for_entry(&file_level, &entry) {
+            let file_line = format_csv_line(&ts, &entry);
+            write_file(&mut file, &file_line).await;
         }
 
         // ─── ターミナル出力（カラー付き従来フォーマット）─────────────────────
@@ -337,7 +269,7 @@ async fn writer_task(
                         "{}\n{} {}",
                         SEPARATOR.bright_green().dimmed(),
                         format!("[{ts}] [MATCH]").bright_green().bold(),
-                        format!("  ルール={rule_name} | パス={path} | {event_str}")
+                        format!("  パス={path} | イベント={event_str} | ルール={rule_name}")
                     );
                     println!("{}", term_line);
                 }
@@ -445,7 +377,7 @@ fn format_events(events: &HashSet<crate::config::Event>) -> String {
         })
         .collect();
     names.sort();
-    names.join(",")
+    names.join("|")
 }
 
 #[cfg(test)]
@@ -483,14 +415,15 @@ mod tests {
         assert_eq!(s, "VERYLONGTEXT");
     }
 
-    /// 罫線なしのレベル文字列が CJK 列幅 7 列で揃う
+    /// pad_left_display で同じ幅に揃えられることを確認
     #[test]
     fn test_pad_left_display_info_aligns_with_match() {
-        let info = pad_left_display("INFO", FILE_LEVEL_WIDTH);
-        let match_ = pad_left_display("MATCH", FILE_LEVEL_WIDTH);
-        let action_ok = pad_left_display("│   OK", FILE_LEVEL_WIDTH);
-        assert_eq!(UnicodeWidthStr::width_cjk(info.as_str()), FILE_LEVEL_WIDTH);
-        assert_eq!(UnicodeWidthStr::width_cjk(match_.as_str()), FILE_LEVEL_WIDTH);
-        assert_eq!(UnicodeWidthStr::width_cjk(action_ok.as_str()), FILE_LEVEL_WIDTH);
+        let width = 7;
+        let info = pad_left_display("INFO", width);
+        let match_ = pad_left_display("MATCH", width);
+        let action_ok = pad_left_display("│   OK", width);
+        assert_eq!(UnicodeWidthStr::width_cjk(info.as_str()), width);
+        assert_eq!(UnicodeWidthStr::width_cjk(match_.as_str()), width);
+        assert_eq!(UnicodeWidthStr::width_cjk(action_ok.as_str()), width);
     }
 }

--- a/cat-watcher/src/logger.rs
+++ b/cat-watcher/src/logger.rs
@@ -13,12 +13,14 @@ use unicode_width::UnicodeWidthStr;
 
 const SEPARATOR: &str = "──────────────────────────────────────────────────────────────";
 
+const FILE_LEVEL_WIDTH: usize = 7;
+const FILE_EVENTS_WIDTH: usize = 27;
+
 /// 表示列幅 (East Asian Width, CJK モード) で左寄せパディングする。
 /// Rust 標準の `format!("{:<width$}")` は char 数で揃えるため、
 /// '└' '│' '├' '─' などの罫線記号で表示時に列幅がズレる。
 /// 本プロジェクトは日本語ロケール (CJK) を主用途とするため、
 /// East Asian Ambiguous 文字を 2 列幅として扱う `width_cjk()` を使う。
-#[allow(dead_code)]
 fn pad_left_display(s: &str, total_cols: usize) -> String {
     let w = UnicodeWidthStr::width_cjk(s);
     if w >= total_cols {
@@ -194,28 +196,79 @@ async fn open_log_file(path: &PathBuf) -> Option<tokio::fs::File> {
     }
 }
 
-/// ファイルログ用 CSV 1行を生成する。
-/// フォーマット:
-///   MATCH:     timestamp,MATCH,path,events,rule_name
-///   ACTION:    timestamp,ACTION,index/total,type,detail
-///   SUCCESS:   timestamp,SUCCESS,msg
-///   INFO/WARN/ERROR: timestamp,LEVEL,msg
-fn format_csv_line(ts: &str, entry: &LogEntry) -> String {
+/// アクション種別を最大4文字の短縮名に変換する。
+fn action_type_short(action_type: &str) -> &str {
+    match action_type {
+        "copy" => "copy",
+        "move" => "move",
+        "command" => "cmd",
+        "execute" => "exec",
+        "log" => "log",
+        other => {
+            if other.len() <= 4 { other } else { &other[..4] }
+        }
+    }
+}
+
+/// ファイルログ用 level カラム文字列（FILE_LEVEL_WIDTH **列** 幅）を生成する。
+/// 全角記号 ('└' '├' '│') を含むため、char 数ではなく表示列幅でパディングする。
+fn file_level_col(entry: &LogEntry) -> String {
     match entry {
-        LogEntry::Match { rule_name, path, events } => {
-            let ev = format_events(events);
-            format!("{ts},MATCH,{path},{ev},{rule_name}\n")
+        LogEntry::Match { .. } => pad_left_display("MATCH", FILE_LEVEL_WIDTH),
+        LogEntry::Action { index, total, action_type, .. } => {
+            let tree = if *index == *total { '└' } else { '├' };
+            let short = action_type_short(action_type);
+            let index_str = index.to_string();
+            // tree ('└'/'├' は CJK で 列幅 2) + index + space(1) + type で
+            // FILE_LEVEL_WIDTH 列に収める。type も CJK 列幅基準で切り詰める。
+            let used_cols = 2 + index_str.len() + 1;
+            let type_max_cols = FILE_LEVEL_WIDTH.saturating_sub(used_cols);
+            let mut type_part = String::new();
+            let mut used = 0usize;
+            for c in short.chars() {
+                let cw = UnicodeWidthStr::width_cjk(c.to_string().as_str());
+                if used + cw > type_max_cols { break; }
+                type_part.push(c);
+                used += cw;
+            }
+            let head = format!("{}{} {}", tree, index_str, type_part);
+            pad_left_display(&head, FILE_LEVEL_WIDTH)
         }
-        LogEntry::Action { index, total, action_type, detail } => {
-            let detail = detail.replace('\n', r"\n");
-            format!("{ts},ACTION,{index}/{total},{action_type},{detail}\n")
+        LogEntry::ActionOk { index, total, .. } => {
+            if *index == *total {
+                // 最終ステップ完了: 継続パイプなし
+                pad_left_display("   OK", FILE_LEVEL_WIDTH)
+            } else {
+                // 中間ステップ完了: 継続パイプあり ('│' は列幅 2)
+                pad_left_display("│   OK", FILE_LEVEL_WIDTH)
+            }
         }
-        LogEntry::ActionOk { index, total, msg } => {
-            format!("{ts},SUCCESS,{index}/{total},{msg}\n")
-        }
-        LogEntry::Info(msg) => format!("{ts},INFO,{msg}\n"),
-        LogEntry::Warn(msg) => format!("{ts},WARN,{msg}\n"),
-        LogEntry::Error(msg) => format!("{ts},ERROR,{msg}\n"),
+        LogEntry::Info(_) => pad_left_display("INFO", FILE_LEVEL_WIDTH),
+        LogEntry::Warn(_) => pad_left_display("WARN", FILE_LEVEL_WIDTH),
+        LogEntry::Error(_) => pad_left_display("ERROR", FILE_LEVEL_WIDTH),
+        LogEntry::Shutdown => unreachable!(),
+    }
+}
+
+/// ファイルログ用 events カラム文字列（FILE_EVENTS_WIDTH **列** 幅）を生成する。
+/// MATCH エントリのみイベント名を出力し、それ以外は空白で埋める。
+fn file_events_col(entry: &LogEntry) -> String {
+    let s = match entry {
+        LogEntry::Match { events, .. } => format_events(events),
+        _ => String::new(),
+    };
+    pad_left_display(&s, FILE_EVENTS_WIDTH)
+}
+
+/// ファイルログ用 content カラムを生成する。
+fn file_content(entry: &LogEntry) -> String {
+    match entry {
+        LogEntry::Match { path, .. } => path.clone(),
+        LogEntry::Action { detail, .. } => detail.replace('\n', r"\n"),
+        LogEntry::ActionOk { msg, .. } => msg.clone(),
+        LogEntry::Info(msg) => msg.clone(),
+        LogEntry::Warn(msg) => msg.clone(),
+        LogEntry::Error(msg) => msg.clone(),
         LogEntry::Shutdown => unreachable!(),
     }
 }
@@ -253,10 +306,25 @@ async fn writer_task(
 
         let ts = now.format("%Y-%m-%d %H:%M:%S").to_string();
 
-        // ─── ファイルログ（CSV形式）────────────────────────────────────────
-        if log_to_file && level_enabled_for_entry(&file_level, &entry) {
-            let file_line = format_csv_line(&ts, &entry);
-            write_file(&mut file, &file_line).await;
+        // ─── ファイルログ（4カラム固定幅フォーマット）───────────────────────
+        if log_to_file {
+            let file_line = match &entry {
+                LogEntry::Match { .. } | LogEntry::Action { .. } | LogEntry::ActionOk { .. }
+                | LogEntry::Info(_) | LogEntry::Warn(_) | LogEntry::Error(_) => {
+                    if !level_enabled_for_entry(&file_level, &entry) {
+                        String::new()
+                    } else {
+                        let lv = file_level_col(&entry);
+                        let ev = file_events_col(&entry);
+                        let ct = file_content(&entry);
+                        format!("{} │ {} │ {} │ {}\n", ts, lv, ev, ct)
+                    }
+                }
+                LogEntry::Shutdown => unreachable!(),
+            };
+            if !file_line.is_empty() {
+                write_file(&mut file, &file_line).await;
+            }
         }
 
         // ─── ターミナル出力（カラー付き従来フォーマット）─────────────────────
@@ -269,7 +337,7 @@ async fn writer_task(
                         "{}\n{} {}",
                         SEPARATOR.bright_green().dimmed(),
                         format!("[{ts}] [MATCH]").bright_green().bold(),
-                        format!("  パス={path} | イベント={event_str} | ルール={rule_name}")
+                        format!("  ルール={rule_name} | パス={path} | {event_str}")
                     );
                     println!("{}", term_line);
                 }
@@ -377,7 +445,7 @@ fn format_events(events: &HashSet<crate::config::Event>) -> String {
         })
         .collect();
     names.sort();
-    names.join("|")
+    names.join(",")
 }
 
 #[cfg(test)]
@@ -415,15 +483,14 @@ mod tests {
         assert_eq!(s, "VERYLONGTEXT");
     }
 
-    /// pad_left_display で同じ幅に揃えられることを確認
+    /// 罫線なしのレベル文字列が CJK 列幅 7 列で揃う
     #[test]
     fn test_pad_left_display_info_aligns_with_match() {
-        let width = 7;
-        let info = pad_left_display("INFO", width);
-        let match_ = pad_left_display("MATCH", width);
-        let action_ok = pad_left_display("│   OK", width);
-        assert_eq!(UnicodeWidthStr::width_cjk(info.as_str()), width);
-        assert_eq!(UnicodeWidthStr::width_cjk(match_.as_str()), width);
-        assert_eq!(UnicodeWidthStr::width_cjk(action_ok.as_str()), width);
+        let info = pad_left_display("INFO", FILE_LEVEL_WIDTH);
+        let match_ = pad_left_display("MATCH", FILE_LEVEL_WIDTH);
+        let action_ok = pad_left_display("│   OK", FILE_LEVEL_WIDTH);
+        assert_eq!(UnicodeWidthStr::width_cjk(info.as_str()), FILE_LEVEL_WIDTH);
+        assert_eq!(UnicodeWidthStr::width_cjk(match_.as_str()), FILE_LEVEL_WIDTH);
+        assert_eq!(UnicodeWidthStr::width_cjk(action_ok.as_str()), FILE_LEVEL_WIDTH);
     }
 }

--- a/cat-watcher/src/main.rs
+++ b/cat-watcher/src/main.rs
@@ -95,6 +95,8 @@ struct Args {
 }
 
 fn main() {
+    // StartServiceCtrlDispatcherW は tokio ランタイム生成より先に
+    // メインスレッドから直接呼ぶ必要がある（エラー1053回避）
     #[cfg(windows)]
     if service::try_run_as_service() {
         return;
@@ -212,4 +214,3 @@ fn run_init(init_type: &InitType, output: Option<&std::path::Path>) -> Result<()
     }
     Ok(())
 }
-

--- a/cat-watcher/src/main.rs
+++ b/cat-watcher/src/main.rs
@@ -14,6 +14,8 @@ mod error;
 mod logger;
 mod placeholder;
 mod router;
+#[cfg(windows)]
+mod service;
 mod templates;
 mod watcher;
 
@@ -93,6 +95,11 @@ struct Args {
 }
 
 fn main() {
+    #[cfg(windows)]
+    if service::try_run_as_service() {
+        return;
+    }
+
     let args = Args::parse();
 
     if let Some(ref csv_path) = args.from_csv {

--- a/cat-watcher/src/main.rs
+++ b/cat-watcher/src/main.rs
@@ -129,12 +129,19 @@ fn main() {
         return;
     }
 
-    let result = tokio::runtime::Builder::new_multi_thread()
+    let rt = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .expect("tokioランタイム作成失敗")
-        .block_on(run(&args));
-    match result {
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
+            eprintln!("{}", format!("[{ts}] [ERROR] tokioランタイム作成失敗: {e}").red().bold());
+            std::process::exit(1);
+        }
+    };
+
+    match rt.block_on(run(&args)) {
         Ok(_) => std::process::exit(0),
         Err(e) => {
             let ts = Local::now().format("%Y-%m-%d %H:%M:%S");

--- a/cat-watcher/src/service.rs
+++ b/cat-watcher/src/service.rs
@@ -102,7 +102,7 @@ fn run_watcher(
         .set_service_status(ServiceStatus {
             service_type: ServiceType::OWN_PROCESS,
             current_state: ServiceState::Running,
-            controls_accepted: ServiceControlAccept::STOP,
+            controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
             exit_code: ServiceExitCode::Win32(0),
             checkpoint: 0,
             wait_hint: Duration::default(),
@@ -110,7 +110,9 @@ fn run_watcher(
         })
         .map_err(|e| AppError::Config(format!("サービス状態設定失敗: {e}")))?;
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
         .map_err(|e| AppError::Config(format!("tokioランタイム作成失敗: {e}")))?;
 
     rt.block_on(async {
@@ -151,21 +153,21 @@ struct ServiceArgs {
 
 /// SCM が binPath= で指定したコマンドラインから --global / --rules を取り出す。
 fn parse_service_args() -> Result<ServiceArgs, AppError> {
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<OsString> = std::env::args_os().collect();
 
     let mut global = None;
     let mut rules = None;
 
     let mut i = 1;
     while i < args.len() {
-        match args[i].as_str() {
-            "--global" | "-g" => {
+        match args[i].to_str() {
+            Some("--global") | Some("-g") => {
                 i += 1;
                 if i < args.len() {
                     global = Some(PathBuf::from(&args[i]));
                 }
             }
-            "--rules" | "-r" => {
+            Some("--rules") | Some("-r") => {
                 i += 1;
                 if i < args.len() {
                     rules = Some(PathBuf::from(&args[i]));

--- a/cat-watcher/src/service.rs
+++ b/cat-watcher/src/service.rs
@@ -76,7 +76,7 @@ fn run_service(arguments: &[OsString]) -> Result<(), AppError> {
     let status_handle = service_control_handler::register(service_name, event_handler)
         .map_err(|e| AppError::Config(format!("SCM登録失敗: {e}")))?;
 
-    let result = run_watcher(&status_handle, stop_rx);
+    let result = run_watcher(status_handle, stop_rx);
 
     let exit_code = if result.is_ok() { 0 } else { 1 };
     let _ = status_handle.set_service_status(ServiceStatus {
@@ -93,7 +93,7 @@ fn run_service(arguments: &[OsString]) -> Result<(), AppError> {
 }
 
 fn run_watcher(
-    status_handle: &ServiceStatusHandle,
+    status_handle: ServiceStatusHandle,
     stop_rx: tokio::sync::oneshot::Receiver<()>,
 ) -> Result<(), AppError> {
     let args = parse_service_args()?;
@@ -134,6 +134,15 @@ fn run_watcher(
         let result = tokio::select! {
             result = watcher::start_watching(&rules_conf.rules, &service_global, Arc::clone(&log)) => result,
             _ = stop_rx => {
+                let _ = status_handle.set_service_status(ServiceStatus {
+                    service_type: ServiceType::OWN_PROCESS,
+                    current_state: ServiceState::StopPending,
+                    controls_accepted: ServiceControlAccept::empty(),
+                    exit_code: ServiceExitCode::Win32(0),
+                    checkpoint: 0,
+                    wait_hint: Duration::from_secs(5),
+                    process_id: None,
+                });
                 log.info("サービス停止シグナルを受信しました".to_string());
                 Ok(())
             }
@@ -165,12 +174,16 @@ fn parse_service_args() -> Result<ServiceArgs, AppError> {
                 i += 1;
                 if i < args.len() {
                     global = Some(PathBuf::from(&args[i]));
+                } else {
+                    return Err(AppError::Config("--global の値が未指定です".to_string()));
                 }
             }
             Some("--rules") | Some("-r") => {
                 i += 1;
                 if i < args.len() {
                     rules = Some(PathBuf::from(&args[i]));
+                } else {
+                    return Err(AppError::Config("--rules の値が未指定です".to_string()));
                 }
             }
             _ => {}

--- a/cat-watcher/src/service.rs
+++ b/cat-watcher/src/service.rs
@@ -27,14 +27,28 @@ define_windows_service!(ffi_service_main, service_main);
 /// SCM からの起動を試みる。サービスとして起動されていた場合は処理完了まで
 /// ブロックして true を返す。通常の CLI 起動の場合は即座に false を返す。
 pub fn try_run_as_service() -> bool {
-    service_dispatcher::start(SERVICE_NAME, ffi_service_main).is_ok()
+    match service_dispatcher::start(SERVICE_NAME, ffi_service_main) {
+        Ok(_) => true,
+        Err(ref e) if is_not_service_context(e) => false,
+        Err(e) => {
+            eprintln!("サービスディスパッチャー起動失敗: {e}");
+            std::process::exit(1);
+        }
+    }
 }
 
-fn service_main(_arguments: Vec<OsString>) {
-    let _ = run_service();
+// ERROR_FAILED_SERVICE_CONTROLLER_CONNECT (1063) = CLI から直接起動された
+fn is_not_service_context(e: &windows_service::Error) -> bool {
+    matches!(e, windows_service::Error::Winapi(ref io_err) if io_err.raw_os_error() == Some(1063))
 }
 
-fn run_service() -> Result<(), AppError> {
+fn service_main(arguments: Vec<OsString>) {
+    if let Err(e) = run_service(&arguments) {
+        eprintln!("サービス実行エラー: {e}");
+    }
+}
+
+fn run_service(arguments: &[OsString]) -> Result<(), AppError> {
     let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
     let stop_tx = Arc::new(Mutex::new(Some(stop_tx)));
 
@@ -54,7 +68,12 @@ fn run_service() -> Result<(), AppError> {
         }
     };
 
-    let status_handle = service_control_handler::register(SERVICE_NAME, event_handler)
+    let service_name = arguments
+        .first()
+        .and_then(|s| s.to_str())
+        .unwrap_or(SERVICE_NAME);
+
+    let status_handle = service_control_handler::register(service_name, event_handler)
         .map_err(|e| AppError::Config(format!("SCM登録失敗: {e}")))?;
 
     let result = run_watcher(&status_handle, stop_rx);
@@ -110,19 +129,18 @@ fn run_watcher(
 
         log.info("Windowsサービスとして起動しました".to_string());
 
-        tokio::select! {
-            result = watcher::start_watching(&rules_conf.rules, &service_global, Arc::clone(&log)) => {
-                result?;
-            }
+        let result = tokio::select! {
+            result = watcher::start_watching(&rules_conf.rules, &service_global, Arc::clone(&log)) => result,
             _ = stop_rx => {
                 log.info("サービス停止シグナルを受信しました".to_string());
+                Ok(())
             }
-        }
+        };
 
         log.shutdown();
         let _ = log_handle.await;
 
-        Ok::<(), AppError>(())
+        result
     })
 }
 

--- a/cat-watcher/src/service.rs
+++ b/cat-watcher/src/service.rs
@@ -1,0 +1,169 @@
+#![cfg(windows)]
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use windows_service::{
+    define_windows_service,
+    service::{
+        ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
+        ServiceType,
+    },
+    service_control_handler::{self, ServiceControlHandlerResult, ServiceStatusHandle},
+    service_dispatcher,
+};
+
+use crate::config;
+use crate::error::AppError;
+use crate::logger::Logger;
+use crate::watcher;
+
+const SERVICE_NAME: &str = "cat-watcher";
+
+define_windows_service!(ffi_service_main, service_main);
+
+/// SCM からの起動を試みる。サービスとして起動されていた場合は処理完了まで
+/// ブロックして true を返す。通常の CLI 起動の場合は即座に false を返す。
+pub fn try_run_as_service() -> bool {
+    service_dispatcher::start(SERVICE_NAME, ffi_service_main).is_ok()
+}
+
+fn service_main(_arguments: Vec<OsString>) {
+    let _ = run_service();
+}
+
+fn run_service() -> Result<(), AppError> {
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let stop_tx = Arc::new(Mutex::new(Some(stop_tx)));
+
+    let stop_tx_for_handler = Arc::clone(&stop_tx);
+    let event_handler = move |control_event| -> ServiceControlHandlerResult {
+        match control_event {
+            ServiceControl::Stop | ServiceControl::Shutdown => {
+                if let Ok(mut guard) = stop_tx_for_handler.lock() {
+                    if let Some(tx) = guard.take() {
+                        let _ = tx.send(());
+                    }
+                }
+                ServiceControlHandlerResult::NoError
+            }
+            ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+            _ => ServiceControlHandlerResult::NotImplemented,
+        }
+    };
+
+    let status_handle = service_control_handler::register(SERVICE_NAME, event_handler)
+        .map_err(|e| AppError::Config(format!("SCM登録失敗: {e}")))?;
+
+    let result = run_watcher(&status_handle, stop_rx);
+
+    let exit_code = if result.is_ok() { 0 } else { 1 };
+    let _ = status_handle.set_service_status(ServiceStatus {
+        service_type: ServiceType::OWN_PROCESS,
+        current_state: ServiceState::Stopped,
+        controls_accepted: ServiceControlAccept::empty(),
+        exit_code: ServiceExitCode::Win32(exit_code),
+        checkpoint: 0,
+        wait_hint: Duration::default(),
+        process_id: None,
+    });
+
+    result
+}
+
+fn run_watcher(
+    status_handle: &ServiceStatusHandle,
+    stop_rx: tokio::sync::oneshot::Receiver<()>,
+) -> Result<(), AppError> {
+    let args = parse_service_args()?;
+
+    status_handle
+        .set_service_status(ServiceStatus {
+            service_type: ServiceType::OWN_PROCESS,
+            current_state: ServiceState::Running,
+            controls_accepted: ServiceControlAccept::STOP,
+            exit_code: ServiceExitCode::Win32(0),
+            checkpoint: 0,
+            wait_hint: Duration::default(),
+            process_id: None,
+        })
+        .map_err(|e| AppError::Config(format!("サービス状態設定失敗: {e}")))?;
+
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| AppError::Config(format!("tokioランタイム作成失敗: {e}")))?;
+
+    rt.block_on(async {
+        let global_config = config::load_global_config(&args.global)?;
+        let rules_conf = config::load_rules_config(&args.rules)?;
+
+        config::validate_global_config(&global_config)?;
+        config::validate_rules_config(&rules_conf)?;
+
+        // サービスモードではコンソール出力を無効化する
+        let mut service_global = global_config.global.clone();
+        service_global.log_to_console = false;
+
+        let (log, log_handle) = Logger::new(&service_global)?;
+        let log = Arc::new(log);
+
+        log.info("Windowsサービスとして起動しました".to_string());
+
+        tokio::select! {
+            result = watcher::start_watching(&rules_conf.rules, &service_global, Arc::clone(&log)) => {
+                result?;
+            }
+            _ = stop_rx => {
+                log.info("サービス停止シグナルを受信しました".to_string());
+            }
+        }
+
+        log.shutdown();
+        let _ = log_handle.await;
+
+        Ok::<(), AppError>(())
+    })
+}
+
+struct ServiceArgs {
+    global: PathBuf,
+    rules: PathBuf,
+}
+
+/// SCM が binPath= で指定したコマンドラインから --global / --rules を取り出す。
+fn parse_service_args() -> Result<ServiceArgs, AppError> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let mut global = None;
+    let mut rules = None;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--global" | "-g" => {
+                i += 1;
+                if i < args.len() {
+                    global = Some(PathBuf::from(&args[i]));
+                }
+            }
+            "--rules" | "-r" => {
+                i += 1;
+                if i < args.len() {
+                    rules = Some(PathBuf::from(&args[i]));
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let global = global.ok_or_else(|| {
+        AppError::Config("--global オプションが未指定です".to_string())
+    })?;
+    let rules = rules.ok_or_else(|| {
+        AppError::Config("--rules オプションが未指定です".to_string())
+    })?;
+
+    Ok(ServiceArgs { global, rules })
+}


### PR DESCRIPTION
windows-service クレートを Windows ターゲット限定で追加し、
service.rs に SCM 連携ロジックを集約。
main() 冒頭で service_dispatcher::start() を試みて SCM 起動を
自動検知し、通常 CLI 起動のパスは一切変更しない。

サービスモード時はコンソールログを自動無効化し、
SCM の Stop/Shutdown イベントを tokio::select! でキャプチャして
graceful shutdown を実現。Linux / macOS は #[cfg(windows)] で
コードごと除外され、クロスコンパイルに影響しない。

https://claude.ai/code/session_01L2rLLH7V1rFytAgVxT95c6