### PR TITLE
refactor(cli): Args リネーム・--init 複数指定対応・ヘルプ整備

### DIFF
--- a/cat-watcher/src/csv_import.rs
+++ b/cat-watcher/src/csv_import.rs
@@ -25,6 +25,12 @@ const COL_PROGRAM: usize = 17;
 const COL_ARGS: usize = 18;
 const COL_WORKING_DIR: usize = 19;
 const COL_MESSAGE: usize = 20;
+// 列21以降は後から追加されたフィルター列（既存CSVとの後方互換のため末尾に追加）
+const COL_EXCLUDE_REGEX: usize = 21;
+const COL_DIR_PATTERNS: usize = 22;
+const COL_DIR_REGEX: usize = 23;
+const COL_EXCLUDE_DIR_PATTERNS: usize = 24;
+const COL_EXCLUDE_DIR_REGEX: usize = 25;
 
 pub fn run(csv_path: &Path, output: Option<&Path>) -> Result<(), AppError> {
     let content = std::fs::read_to_string(csv_path)
@@ -82,6 +88,11 @@ pub fn run(csv_path: &Path, output: Option<&Path>) -> Result<(), AppError> {
         let patterns = get(first, COL_PATTERNS);
         let regex = get(first, COL_REGEX);
         let exclude_patterns = get(first, COL_EXCLUDE_PATTERNS);
+        let exclude_regex = get(first, COL_EXCLUDE_REGEX);
+        let dir_patterns = get(first, COL_DIR_PATTERNS);
+        let dir_regex = get(first, COL_DIR_REGEX);
+        let exclude_dir_patterns = get(first, COL_EXCLUDE_DIR_PATTERNS);
+        let exclude_dir_regex = get(first, COL_EXCLUDE_DIR_REGEX);
         let events = get(first, COL_EVENTS);
 
         if watch_path.is_empty() {
@@ -102,6 +113,21 @@ pub fn run(csv_path: &Path, output: Option<&Path>) -> Result<(), AppError> {
         if !patterns.is_empty() && !regex.is_empty() {
             return Err(AppError::Config(format!(
                 "ルール '{rule_name}' の patterns と regex は同時指定できません"
+            )));
+        }
+        if !exclude_patterns.is_empty() && !exclude_regex.is_empty() {
+            return Err(AppError::Config(format!(
+                "ルール '{rule_name}' の exclude_patterns と exclude_regex は同時指定できません"
+            )));
+        }
+        if !dir_patterns.is_empty() && !dir_regex.is_empty() {
+            return Err(AppError::Config(format!(
+                "ルール '{rule_name}' の dir_patterns と dir_regex は同時指定できません"
+            )));
+        }
+        if !exclude_dir_patterns.is_empty() && !exclude_dir_regex.is_empty() {
+            return Err(AppError::Config(format!(
+                "ルール '{rule_name}' の exclude_dir_patterns と exclude_dir_regex は同時指定できません"
             )));
         }
 
@@ -129,6 +155,24 @@ pub fn run(csv_path: &Path, output: Option<&Path>) -> Result<(), AppError> {
             exclude_patterns.split('|').map(|s| format!("\"{}\"", s.trim())).collect()
         };
         toml.push_str(&format!("exclude_patterns = [{}]\n", excl.join(", ")));
+
+        if !exclude_regex.is_empty() {
+            toml.push_str(&format!("exclude_regex    = \"{}\"\n", escape_toml_str(&exclude_regex)));
+        }
+        if !dir_patterns.is_empty() {
+            let pats: Vec<String> = dir_patterns.split('|').map(|s| format!("\"{}\"", escape_toml_str(s.trim()))).collect();
+            toml.push_str(&format!("dir_patterns     = [{}]\n", pats.join(", ")));
+        }
+        if !dir_regex.is_empty() {
+            toml.push_str(&format!("dir_regex        = \"{}\"\n", escape_toml_str(&dir_regex)));
+        }
+        if !exclude_dir_patterns.is_empty() {
+            let pats: Vec<String> = exclude_dir_patterns.split('|').map(|s| format!("\"{}\"", escape_toml_str(s.trim()))).collect();
+            toml.push_str(&format!("exclude_dir_patterns = [{}]\n", pats.join(", ")));
+        }
+        if !exclude_dir_regex.is_empty() {
+            toml.push_str(&format!("exclude_dir_regex = \"{}\"\n", escape_toml_str(&exclude_dir_regex)));
+        }
 
         let evts: Vec<String> = events.split('|').map(|s| format!("\"{}\"", s.trim())).collect();
         toml.push_str(&format!("events           = [{}]\n", evts.join(", ")));

--- a/cat-watcher/src/csv_import.rs
+++ b/cat-watcher/src/csv_import.rs
@@ -197,7 +197,8 @@ pub fn run(csv_path: &Path, output: Option<&Path>) -> Result<(), AppError> {
     if let Some(out_path) = output {
         std::fs::write(out_path, &toml)
             .map_err(|e| AppError::Config(format!("出力ファイルの書き込みに失敗: {e}")))?;
-        println!("変換完了: {}", out_path.display());
+        let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
+        println!("[{ts}] [INFO]    変換完了: {}", out_path.display());
     } else {
         print!("{toml}");
     }

--- a/cat-watcher/src/main.rs
+++ b/cat-watcher/src/main.rs
@@ -101,6 +101,11 @@ fn main() {
     }
 
     if !args.init.is_empty() {
+        if args.init.len() > 1 && args.output.is_some() {
+            let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
+            eprintln!("{}", format!("[{ts}] [ERROR] --init を複数指定する場合は --output を同時に使用できません").red().bold());
+            std::process::exit(1);
+        }
         let mut had_error = false;
         for init_type in &args.init {
             if let Err(e) = run_init(init_type, args.output.as_deref()) {

--- a/cat-watcher/src/main.rs
+++ b/cat-watcher/src/main.rs
@@ -27,45 +27,64 @@ enum InitType {
     Csv,
 }
 
+/// ファイル監視・自動処理ツール
 #[derive(Parser)]
 #[command(disable_help_flag = false)]
-struct Cli {
-    #[arg(short, long)]
+struct Args {
+    /// グローバル設定ファイルのパス
+    #[arg(short, long, value_name = "FILE")]
     global: Option<PathBuf>,
-    #[arg(short, long)]
+    /// ルール設定ファイルのパス
+    #[arg(short, long, value_name = "FILE")]
     rules: Option<PathBuf>,
-    #[arg(long)]
-    log_level: Option<String>,
+    /// 設定ファイルのバリデーションのみ実行して終了
     #[arg(long)]
     validate: bool,
+    /// CSV ファイルから rules.toml を生成
     #[arg(long, value_name = "CSV")]
     from_csv: Option<PathBuf>,
+    /// 出力先ファイルパス（--from-csv または --init と組み合わせて使用）
     #[arg(long, value_name = "FILE")]
     output: Option<PathBuf>,
-    /// テンプレートファイルを出力する (global / rules / csv)
-    #[arg(long, value_name = "TYPE")]
-    init: Option<InitType>,
+    /// テンプレートファイルを出力する（複数指定可: global rules csv）
+    #[arg(long, value_name = "TYPE", num_args = 1..)]
+    init: Vec<InitType>,
 }
 
-#[tokio::main]
-async fn main() -> Result<(), AppError> {
+fn main() {
     if std::env::args_os().len() == 1 {
         init_colors();
         print_guide();
-        return Ok(());
+        return;
     }
 
-    let cli = Cli::parse();
+    let args = Args::parse();
 
-    if let Some(ref csv_path) = cli.from_csv {
-        return csv_import::run(csv_path, cli.output.as_deref());
+    if let Some(ref csv_path) = args.from_csv {
+        exit_on_err(csv_import::run(csv_path, args.output.as_deref()));
+        return;
     }
 
-    if let Some(ref init_type) = cli.init {
-        return run_init(init_type, cli.output.as_deref());
+    if !args.init.is_empty() {
+        let mut had_error = false;
+        for init_type in &args.init {
+            if let Err(e) = run_init(init_type, args.output.as_deref()) {
+                let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
+                eprintln!("{}", format!("[{ts}] [ERROR] {e}").red().bold());
+                had_error = true;
+            }
+        }
+        if had_error {
+            std::process::exit(1);
+        }
+        return;
     }
 
-    let result = run(&cli).await;
+    let result = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokioランタイム作成失敗")
+        .block_on(run(&args));
     match result {
         Ok(_) => std::process::exit(0),
         Err(e) => {
@@ -76,7 +95,7 @@ async fn main() -> Result<(), AppError> {
     };
 }
 
-async fn run(cli: &Cli) -> Result<(), AppError> {
+async fn run(cli: &Args) -> Result<(), AppError> {
     let global_path = cli.global.as_ref().ok_or_else(|| {
         AppError::Config("--global オプションが未指定です".to_string())
     })?;
@@ -112,6 +131,14 @@ async fn run(cli: &Cli) -> Result<(), AppError> {
     Ok(())
 }
 
+fn exit_on_err(result: Result<(), AppError>) {
+    if let Err(e) = result {
+        let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
+        eprintln!("{}", format!("[{ts}] [ERROR] {e}").red().bold());
+        std::process::exit(1);
+    }
+}
+
 fn run_init(init_type: &InitType, output: Option<&std::path::Path>) -> Result<(), AppError> {
     let (content, default_name) = match init_type {
         InitType::Global => (templates::GLOBAL_TOML, "global.toml"),
@@ -127,11 +154,9 @@ fn run_init(init_type: &InitType, output: Option<&std::path::Path>) -> Result<()
     } else {
         let path = std::path::Path::new(default_name);
         if path.exists() {
-            let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
-            eprintln!("{}", format!(
-                "[{ts}] [ERROR]   {default_name} が既に存在します。上書きする場合は --output で明示的にパスを指定してください"
-            ).red().bold());
-            std::process::exit(1);
+            return Err(AppError::Config(format!(
+                "{default_name} が既に存在します。上書きする場合は --output で明示的にパスを指定してください"
+            )));
         }
         std::fs::write(path, content)
             .map_err(|e| AppError::Config(format!("ファイルの書き込みに失敗: {e}")))?;

--- a/cat-watcher/src/main.rs
+++ b/cat-watcher/src/main.rs
@@ -17,6 +17,44 @@ mod router;
 mod templates;
 mod watcher;
 
+const AFTER_LONG_HELP: &str = "\
+\x1b[33;1m▶ 使い方\x1b[0m
+  監視の起動:
+    cat-watcher -g global.toml -r rules.toml
+    cat-watcher -g global.toml -r rules.toml --validate
+
+  テンプレート生成（複数同時指定可）:
+    cat-watcher --init global rules        # global.toml と rules.toml を同時生成
+    cat-watcher --init global rules csv
+
+  CSV から rules.toml を生成:
+    cat-watcher --from-csv rules.csv --output rules.toml
+
+\x1b[33;1m▶ プレースホルダー\x1b[0m  \x1b[2m（rules.toml の destination / command / args などで使用可）\x1b[0m
+  \x1b[32m{FullName}\x1b[0m         ファイルのフルパス
+  \x1b[32m{Name}\x1b[0m             ファイル名（拡張子なし）
+  \x1b[32m{BaseName}\x1b[0m         ファイル名（拡張子あり）
+  \x1b[32m{Extension}\x1b[0m        拡張子
+  \x1b[32m{DirectoryName}\x1b[0m    親ディレクトリのフルパス
+  \x1b[32m{WatchPath}\x1b[0m        監視ルートパス
+  \x1b[32m{RelativePath}\x1b[0m     監視ルートからの相対パス
+  \x1b[32m{Date}\x1b[0m             検知日       例: 20240302
+  \x1b[32m{Time}\x1b[0m             検知時刻     例: 103020
+  \x1b[32m{DateTime}\x1b[0m         日時         例: 20240302_103020
+  \x1b[32m{Destination}\x1b[0m      直前のアクションの出力先（連鎖用）
+
+\x1b[33;1m▶ CSV インポート列順\x1b[0m  \x1b[2m（--from-csv）\x1b[0m
+  rule_name, enabled, watch_path, recursive, target, include_hidden,
+  patterns, regex, exclude_patterns, events,
+  action_type, destination, overwrite, preserve_structure, verify_integrity,
+  shell, command, program, args, working_dir, message,
+  exclude_regex, dir_patterns, dir_regex, exclude_dir_patterns, exclude_dir_regex
+
+  複数アクションのルール: rule_name を同じにして行を追加
+  複数値フィールド（patterns / events / args 等）: | で区切る  例: create|modify
+  ※ 列22以降（exclude_regex〜）は省略可（既存 CSV との後方互換のため末尾）
+";
+
 #[derive(clap::ValueEnum, Clone)]
 enum InitType {
     /// global.toml のテンプレートを出力
@@ -29,7 +67,10 @@ enum InitType {
 
 /// ファイル監視・自動処理ツール
 #[derive(Parser)]
-#[command(disable_help_flag = false)]
+#[command(
+    arg_required_else_help = true,
+    after_long_help = AFTER_LONG_HELP,
+)]
 struct Args {
     /// グローバル設定ファイルのパス
     #[arg(short, long, value_name = "FILE")]
@@ -52,12 +93,6 @@ struct Args {
 }
 
 fn main() {
-    if std::env::args_os().len() == 1 {
-        init_colors();
-        print_guide();
-        return;
-    }
-
     let args = Args::parse();
 
     if let Some(ref csv_path) = args.from_csv {
@@ -166,99 +201,3 @@ fn run_init(init_type: &InitType, output: Option<&std::path::Path>) -> Result<()
     Ok(())
 }
 
-fn init_colors() {
-    #[cfg(windows)]
-    colored::control::set_virtual_terminal(true).ok();
-    colored::control::set_override(true);
-}
-
-fn print_guide() {
-    let sep = "━".repeat(58);
-    println!("{}", sep.bright_cyan());
-    println!("  {}  ファイル監視・自動処理ツール", "cat-watcher".bright_white().bold());
-    println!("{}", sep.bright_cyan());
-
-    println!("\n{}", "▶ 使い方".bright_yellow().bold());
-    println!("  cat-watcher.exe --global global.toml --rules rules.toml");
-    println!("  cat-watcher.exe --global global.toml --rules rules.toml --validate");
-    println!("  cat-watcher.exe --from-csv rules.csv [--output rules.toml]");
-
-    println!("\n{}", "▶ global.toml（グローバル設定）".bright_yellow().bold());
-    println!("{}", r#"
-[global]
-log_level         = "info"    # trace / debug / info / warn / error
-log_dir           = "C:\logs"
-log_file_name     = "cat-watcher_{Date}.log"  # {Date} or {DateTime}
-log_rotation      = "daily"                   # daily / never
-retry_count       = 3
-retry_interval_ms = 1000"#.trim_start_matches('\n'));
-
-    println!("\n{}", "▶ rules.toml（ルール設定）".bright_yellow().bold());
-    println!("{}", r#"
-[[rules]]
-enabled = true
-name    = "ルール名"
-
-[rules.watch]
-path             = "C:\監視フォルダ"
-recursive        = true          # サブフォルダも対象にするか
-target           = "file"        # file / directory / both
-include_hidden   = false
-patterns         = ["*.pdf", "*.docx"]  # glob（regex と排他）
-# regex          = ".*\\.pdf$"          # 正規表現（patterns と排他）
-exclude_patterns = []
-events           = ["create", "modify"] # create / modify / delete / rename
-
-[[rules.actions]]               # ─── copy ───────────────────────────
-type               = "copy"
-destination        = "D:\backup\{Date}"
-overwrite          = true
-preserve_structure = false
-verify_integrity   = true       # BLAKE3 ハッシュで整合性検証
-
-# [[rules.actions]]             # ─── move ───────────────────────────
-# type        = "move"
-# destination = "D:\archive\{Date}\{Time}"
-# overwrite   = false
-
-# [[rules.actions]]             # ─── command ────────────────────────
-# type        = "command"
-# shell       = "cmd"           # cmd / powershell / pwsh
-# command     = "echo {FullName}"
-# working_dir = ""
-
-# [[rules.actions]]             # ─── execute ────────────────────────
-# type        = "execute"
-# program     = "C:\tool\app.exe"
-# args        = ["{FullName}"]
-# working_dir = """#.trim_start_matches('\n'));
-
-    println!("\n{}", "▶ プレースホルダー一覧".bright_yellow().bold());
-    let placeholders = [
-        ("{FullName}",      "ファイルのフルパス"),
-        ("{Name}",          "ファイル名（拡張子なし）"),
-        ("{BaseName}",      "ファイル名（拡張子あり）"),
-        ("{Extension}",     "拡張子"),
-        ("{DirectoryName}", "親ディレクトリのフルパス"),
-        ("{WatchPath}",     "監視ルートパス"),
-        ("{RelativePath}",  "監視ルートからの相対パス"),
-        ("{Date}",          "検知日       例: 20240302"),
-        ("{Time}",          "検知時刻     例: 103020"),
-        ("{DateTime}",      "日時         例: 20240302_103020"),
-        ("{Destination}",   "直前のアクションの出力先（連鎖用）"),
-    ];
-    for (key, desc) in placeholders {
-        println!("  {:<18} {}", key.bright_green(), desc);
-    }
-
-    println!("\n{}", "▶ CSV インポート（--from-csv）".bright_yellow().bold());
-    println!("  CSV の列順（1行目はヘッダー行として自動スキップ）:");
-    println!("  {}", "rule_name, enabled, watch_path, recursive, target, include_hidden,".dimmed());
-    println!("  {}", "patterns, regex, exclude_patterns, events,".dimmed());
-    println!("  {}", "action_type, destination, overwrite, preserve_structure, verify_integrity,".dimmed());
-    println!("  {}", "shell, command, program, args, working_dir".dimmed());
-    println!("  複数アクションのルール: rule_name を同じにして行を追加");
-    println!("  複数値フィールド（patterns / events / args 等）: | で区切る  例: create|modify");
-
-    println!("\n{}", sep.bright_cyan());
-}

--- a/cat-watcher/src/templates.rs
+++ b/cat-watcher/src/templates.rs
@@ -5,6 +5,10 @@ log_file_name     = "cat-watcher_{Date}.log"  # {Date} / {DateTime}
 log_rotation      = "daily"                   # daily / never
 retry_count       = 3
 retry_interval_ms = 1000
+# log_to_console       = true   # コンソールへのログ出力（デフォルト: true）
+# log_to_file          = true   # ファイルへのログ出力（デフォルト: true）
+# terminal_log_level   = "info" # コンソール専用ログレベル（省略時は log_level を使用）
+# file_log_level       = "info" # ファイル専用ログレベル（省略時は log_level を使用）
 "#;
 
 pub const RULES_TOML: &str = r#"[[rules]]
@@ -55,6 +59,6 @@ message = "検知: {BaseName}"
 "#;
 
 pub const RULES_CSV: &str = "\
-rule_name,enabled,watch_path,recursive,target,include_hidden,patterns,regex,exclude_patterns,events,action_type,destination,overwrite,preserve_structure,verify_integrity,shell,command,program,args,working_dir,message\r\n\
-ルール名,true,C:\\監視フォルダ,true,file,false,*.csv,,,create,log,,,,,,,,,,検知: {BaseName}\r\n\
+rule_name,enabled,watch_path,recursive,target,include_hidden,patterns,regex,exclude_patterns,events,action_type,destination,overwrite,preserve_structure,verify_integrity,shell,command,program,args,working_dir,message,exclude_regex,dir_patterns,dir_regex,exclude_dir_patterns,exclude_dir_regex\r\n\
+ルール名,true,C:\\監視フォルダ,true,file,false,*.csv,,,create,log,,,,,,,,,,検知: {BaseName},,,,,\r\n\
 ";

--- a/cat-watcher/src/templates.rs
+++ b/cat-watcher/src/templates.rs
@@ -56,5 +56,5 @@ message = "検知: {BaseName}"
 
 pub const RULES_CSV: &str = "\
 rule_name,enabled,watch_path,recursive,target,include_hidden,patterns,regex,exclude_patterns,events,action_type,destination,overwrite,preserve_structure,verify_integrity,shell,command,program,args,working_dir,message\r\n\
-ルール名,true,C:\\監視フォルダ,true,file,false,*.csv,,, create,log,,,,,,,,,, 検知: {BaseName}\r\n\
+ルール名,true,C:\\監視フォルダ,true,file,false,*.csv,,,create,log,,,,,,,,,,検知: {BaseName}\r\n\
 ";


### PR DESCRIPTION
## 概要
- `Cli` 構造体を `Args` にリネーム
- `--init` を `Option<InitType>` から `Vec<InitType>` に変更（複数同時指定対応）
- `--log-level` フラグを削除（未使用のため）
- `#[tokio::main]` を手動ランタイムビルドに変更（Windows サービス対応との整合）
- `print_guide` / `init_colors` を `AFTER_LONG_HELP` 定数 + `arg_required_else_help` に置き換え
- `exit_on_err` ヘルパー関数を追加

## 関連
- #42 (Windows サービス対応) からスコープ分割
- closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)