### PR TITLE
feat(log): ログをsystem/detect/actionの3種に分割

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cat-watcher"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "blake3",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 - **プレースホルダー**: 監視ファイルのパス・名前・日時などを宛先や引数に埋め込める
 - **整合性検証**: BLAKE3 ハッシュでコピー後のファイル一致を確認
 - **リトライ機構**: ロック等で失敗したアクションを自動再試行
-- **ログローテーション**: 日次でログファイルを切り替え（`log_rotation = "never"` で固定ファイルにも対応）
-- **ルール別ログ**: ルールごとに独立したログファイルへ出力（`[rules.log]` セクションで設定）
-- **ログ出力先の個別制御**: コンソール・ファイルを個別に有効/無効、ログレベルも別々に指定可能
+- **ログ3分割**: システムログ（全体の起動日誌）／検知ログ／アクションログを目的別に分離
+- **ログローテーション**: 日次でログファイルを切り替え（`rotation = "never"` で固定ファイルにも対応）
+- **ルール別ログ**: ルールごとに検知ログ・アクションログを独立出力（`[rules.log.detect]` / `[rules.log.action]` で設定）
 - **テンプレート生成**: `--init global rules csv` のように複数のテンプレートを一括で出力できる
 - **ホームディレクトリ展開**: パス設定で `~` が使用可能（`~/logs` など）
 - **全件エラー報告**: 設定ファイルに複数の問題があっても、1 回の起動で全エラーをまとめて表示
@@ -70,22 +70,26 @@ cat-watcher --from-csv rules.csv --output rules.toml
 ### global.toml（グローバル設定）
 
 ```toml
-[global]
-log_level         = "info"                    # trace / debug / info / warn / error
-log_dir           = "C:\\logs"               # ~ によるホームディレクトリ展開も可（例: ~/logs）
-log_file_name     = "cat-watcher_{Date}.log"  # {Date} / {DateTime} を埋め込み可
-log_rotation      = "daily"                   # daily / never
-retry_count       = 3
-retry_interval_ms = 1000
+# リトライ設定（copy / move 失敗時の再試行）
+[retry]
+count       = 3
+interval_ms = 1000
 
-# ログ出力先の制御（省略時はどちらも true）
-log_to_console    = true
-log_to_file       = true
-
-# コンソール・ファイルで異なるログレベルを使いたい場合に設定（省略時は log_level を使用）
-# terminal_log_level = "info"
-# file_log_level     = "debug"
+# システムログ（プログラム全体の起動日誌・全体で1本）
+# 起動バナー / ルール一覧 / 監視開始 / 終了 と、システム階層のエラーを記録する。
+# 検知・アクションの結果は rules.toml の [rules.log] 側に出力される。
+[system_log]
+enabled   = true
+dir       = "C:\\logs"               # ~ によるホームディレクトリ展開も可（例: ~/logs）
+file_name = "system_{Date}.log"       # {Date} / {DateTime} を埋め込み可
+rotation  = "daily"                   # daily / never
+level     = "info"                    # trace / debug / info / warn / error
+console   = true                      # コンソールへの出力 ON/OFF
 ```
+
+> **v1.3.0 でログ設定は破壊的に変更されました。** 旧 `[global]`（`log_level` /
+> `log_dir` / `log_to_file` など）は廃止され、未知のキーがあると起動時にエラーで
+> 停止します。`--init global` で新しいテンプレートを出力できます。
 
 ### rules.toml（ルール定義）
 
@@ -110,12 +114,20 @@ exclude_dir_patterns = ["node_modules"]  # 除外フォルダ名 glob（exclude_
 events           = ["create", "modify"]  # create / modify / delete / rename
 
 # ── ルール別ログ（省略可）──────────────────────────────────────────────────
-# このルールにマッチしたイベントをルール専用のログファイルにも書き出す
-[rules.log]
-enabled       = true
-log_dir       = "D:\\logs\\csv-backup"
-log_file_name = "csv-backup_{Date}.log"  # {Date} / {DateTime} を埋め込み可
-log_rotation  = "daily"                  # daily / never
+# detect: 検知イベントのみを記録（timestamp │ events │ 検知パス）
+# action: 検知ごとのアクション実行内容をブロック形式で記録
+# どちらも enabled で個別に ON/OFF でき、dir / file_name / rotation を各自指定する。
+[rules.log.detect]
+enabled   = true
+dir       = "D:\\logs\\csv-backup"
+file_name = "detect_csv-backup_{Date}.log"  # {Date} / {DateTime} を埋め込み可
+rotation  = "daily"                          # daily / never
+
+[rules.log.action]
+enabled   = true
+dir       = "D:\\logs\\csv-backup"
+file_name = "action_csv-backup_{Date}.log"
+rotation  = "daily"
 
 # ──────────── アクションチェーン ────────────
 [[rules.actions]]
@@ -217,7 +229,7 @@ exclude_dir_patterns = ["node_modules"]  # ただし node_modules は除外
 
 ```
 バリデーションエラーが 3 件見つかりました:
-  [1] log_dir が存在しません: C:\logs\app
+  [1] system_log.dir が存在しません: C:\logs\app
   [2] 監視ルール名 csv-backup の watch.path が存在しません: C:\data\incoming
   [3] 監視ルール名 log-processor のアクションの type が Command のとき、shell を定義してください
 ```
@@ -243,35 +255,54 @@ shell, command, program, args, working_dir, message
 
 ## ログ
 
-ターミナルとファイルでフォーマットが異なります。
+ログは目的別に **3 種類** に分かれます。ターミナルにはこれまで同様すべてが
+色付きで流れますが、ファイルは用途ごとに分割されます。
 
-**ターミナル出力**（カラー付き）
+| 種類 | 出力先 | 内容 |
+|---|---|---|
+| システムログ | 全体で1本（`[system_log]`） | 起動バナー / ルール一覧 / 監視開始 / 終了 とシステム階層のエラー |
+| 検知ログ | ルール別（`[rules.log.detect]`） | 検知したイベントのみ（`timestamp │ events │ 検知パス`） |
+| アクションログ | ルール別（`[rules.log.action]`） | 検知ごとのアクション実行内容（ブロック構造） |
+
+**ターミナル出力**（カラー付き・全種類が流れる）
 
 ```
 ──────────────────────────────────────────────────────────────
-[2026-05-07 10:30:20] [MATCH]   ルール=csv-backup | パス=C:\data\report.csv | Create, Modify
-[2026-05-07 10:30:20] [ACTION]  (1/3) log
-[2026-05-07 10:30:20] [INFO]    検知: report.csv
-[2026-05-07 10:30:20] [ACTION]  (2/3) copy  C:\data\report.csv → D:\backup\20260507
+[2026-05-07 10:30:20] [MATCH]   ルール=csv-backup | パス=C:\data\report.csv | Create,Modify
+[2026-05-07 10:30:20] [ACTION]  (1/2) copy  destination=D:\backup\{Date}  overwrite=false
 [2026-05-07 10:30:20] [OK]      コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
-[2026-05-07 10:30:20] [ACTION]  (3/3) command  shell=powershell  cmd=Write-Host 'Backed up: ...'
-[2026-05-07 10:30:20] [OK]      コマンド完了
+[2026-05-07 10:30:20] [ACTION]  (2/2) log
+[2026-05-07 10:30:20] [OK]      検知: report.csv
 ```
 
-**ファイル出力**（4列固定幅フォーマット）
+**① システムログ**（`system_{Date}.log`）
 
 ```
-2026-05-07 10:30:20 │ INFO    │                             │ cat-watcher 起動
-2026-05-07 10:30:20 │ MATCH   │ Create,Modify               │ C:\data\report.csv
-2026-05-07 10:30:20 │ ├1 log  │                             │
-2026-05-07 10:30:20 │ │   OK  │                             │ 検知: report.csv
-2026-05-07 10:30:20 │ ├2 cop  │                             │ C:\data\report.csv → D:\backup\{Date}
-2026-05-07 10:30:20 │ │   OK  │                             │ コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
-2026-05-07 10:30:20 │ └3 cmd  │                             │ shell=powershell  cmd=Write-Host 'Backed up: ...'
-2026-05-07 10:30:20 │    OK   │                             │ 起動
+2026-05-07 10:30:18 │ INFO  │ cat-watcher 起動  global=... rules=...
+2026-05-07 10:30:18 │ INFO  │ 監視ルール [csv-backup] (有効)  パス=C:\data\incoming  イベント=作成, 変更  サブフォルダ=あり
+2026-05-07 10:30:25 │ INFO  │ 終了シグナル受信
 ```
 
-`log_to_console = false` でターミナル出力を、`log_to_file = false` でファイル出力を無効にできます。`terminal_log_level` / `file_log_level` でそれぞれのログレベルを個別に設定することもできます。
+**② 検知ログ**（`detect_csv-backup_{Date}.log`）
+
+```
+2026-05-07 10:30:20 │ Create,Modify        │ C:\data\report.csv
+```
+
+**③ アクションログ**（`action_csv-backup_{Date}.log`・1検知=1ブロック、`#N` は日次でリセット）
+
+```
+═══ #1  2026-05-07 10:30:20  C:\data\report.csv  (Create,Modify)  actions=2 ═══
+2026-05-07 10:30:20 │ 1. copy   │ destination=D:\backup\{Date}  overwrite=false
+2026-05-07 10:30:20 │ 1. OK     │ コピー完了: C:\data\report.csv → D:\backup\20260507\report.csv  [BLAKE3: ...]
+2026-05-07 10:30:20 │ 2. log    │
+2026-05-07 10:30:20 │ 2. OK     │ 検知: report.csv
+```
+
+アクションが失敗した場合は `1. WARN`（リトライ）→ `1. ERR`（最終失敗）の順に
+**アクションログにのみ** 記録されます（システムログには残りません）。
+`[system_log]` の `console = false` でターミナル出力を、各ログの `enabled = false`
+で個別にファイル出力を無効にできます。
 
 ## Windows サービスとして登録する
 
@@ -306,7 +337,7 @@ sc delete cat-watcher
 
 - `binPath=` の後のパスはすべて **絶対パス** で指定してください（`~` や相対パスは SCM が解釈できません）
 - サービスモードでは **コンソール出力は自動で無効** になり、ファイルログのみ出力されます
-- `global.toml` の `log_to_file = true` と `log_dir` を正しく設定しておく必要があります
+- `global.toml` の `[system_log]`（`enabled` / `dir`）を正しく設定しておく必要があります
 - 通常の CLI 起動（`cat-watcher -g ... -r ...`）の動作は変わりません
 
 ## 開発

--- a/cat-watcher/src/actions/command.rs
+++ b/cat-watcher/src/actions/command.rs
@@ -1,17 +1,15 @@
-use std::sync::Arc;
-
 use std::process::Stdio;
 
-use crate::config::{ActionConfig, Global};
+use crate::config::ActionConfig;
 use crate::error::AppError;
-use crate::logger::Logger;
 use crate::placeholder::{expand_placeholders, PlaceholderContext};
+
+use super::ActionSink;
 
 pub async fn execute(
     action: &ActionConfig,
     ctx: &PlaceholderContext,
-    _global: &Global,
-    log: Arc<Logger>,
+    sink: &ActionSink,
     step: (usize, usize),
 ) -> Result<(), AppError> {
     let raw_command = action
@@ -43,7 +41,7 @@ pub async fn execute(
         ))
     })?;
 
-    log.log_action_ok(step.0, step.1, "起動");
+    sink.ok(step.0, step.1, "起動".to_string());
     Ok(())
 }
 
@@ -97,24 +95,10 @@ fn build_shell_command(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ActionType, Global, LogLevel, LogRotation};
+    use crate::config::{ActionType, LogRotation};
+    use crate::logger::Logger;
+    use std::sync::Arc;
     use tempfile::tempdir;
-
-    fn make_global() -> Global {
-        let dir = tempdir().unwrap();
-        Global {
-            log_level: LogLevel::Info,
-            log_dir: dir.path().to_str().unwrap().to_string(),
-            log_file_name: "test.log".to_string(),
-            log_rotation: LogRotation::Never,
-            retry_count: 0,
-            retry_interval_ms: 0,
-            log_to_console: false,
-            log_to_file: false,
-            terminal_log_level: None,
-            file_log_level: None,
-        }
-    }
 
     fn make_action(shell: &str, command: &str, working_dir: &str) -> ActionConfig {
         ActionConfig {
@@ -136,23 +120,16 @@ mod tests {
         PlaceholderContext::new(src, watch, "")
     }
 
-    fn make_logger() -> Arc<Logger> {
+    fn make_sink() -> ActionSink {
         let dir = tempdir().unwrap();
-        let global = Global {
-            log_level: LogLevel::Info,
-            log_dir: dir.path().to_str().unwrap().to_string(),
-            log_file_name: "test.log".to_string(),
-            log_rotation: LogRotation::Never,
-            retry_count: 0,
-            retry_interval_ms: 0,
-            log_to_console: false,
-            log_to_file: false,
-            terminal_log_level: None,
-            file_log_level: None,
-        };
+        let (logger, _) = Logger::for_action(
+            dir.path().to_str().unwrap().to_string(),
+            "test.log".to_string(),
+            LogRotation::Never,
+        )
+        .unwrap();
         std::mem::forget(dir);
-        let (logger, _) = Logger::new(&global).unwrap();
-        Arc::new(logger)
+        ActionSink::new(Arc::new(logger), None)
     }
 
     #[tokio::test]
@@ -162,8 +139,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("zsh", "echo hi", "");
-        let global = make_global();
-        let result = execute(&action, &ctx, &global, make_logger(), (1, 1)).await;
+        let result = execute(&action, &ctx, &make_sink(), (1, 1)).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("不明なシェル"));
     }
@@ -176,8 +152,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("bash", "echo hello", "");
-        let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
+        assert!(execute(&action, &ctx, &make_sink(), (1, 1)).await.is_ok());
     }
 
     #[cfg(not(windows))]
@@ -188,8 +163,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("sh", "echo hello", "");
-        let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
+        assert!(execute(&action, &ctx, &make_sink(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -200,8 +174,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd", "echo hello", "");
-        let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
+        assert!(execute(&action, &ctx, &make_sink(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -212,8 +185,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd", "echo {Name}", "");
-        let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
+        assert!(execute(&action, &ctx, &make_sink(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -224,8 +196,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd", "echo hi", dir.path().to_str().unwrap());
-        let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
+        assert!(execute(&action, &ctx, &make_sink(), (1, 1)).await.is_ok());
     }
 
     #[test]

--- a/cat-watcher/src/actions/copy.rs
+++ b/cat-watcher/src/actions/copy.rs
@@ -1,15 +1,14 @@
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
-use crate::config::{ActionConfig, Global};
+use crate::config::{ActionConfig, RetryConfig};
 use crate::error::AppError;
-use crate::logger::Logger;
 use crate::placeholder::PlaceholderContext;
 
 use super::common::{
     expand_action_destination, resolve_dest_path, try_copy_once, walk_files,
 };
+use super::ActionSink;
 
 /// copy アクションのエントリポイント。
 /// 戻り値:
@@ -20,8 +19,8 @@ pub async fn execute(
     action: &ActionConfig,
     src: &Path,
     ctx: &PlaceholderContext,
-    global: &Global,
-    log: Arc<Logger>,
+    retry: &RetryConfig,
+    sink: &ActionSink,
     step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     let dest_root = expand_action_destination(action, ctx)?;
@@ -39,14 +38,14 @@ pub async fn execute(
             overwrite,
             preserve_structure,
             verify_integrity,
-            global,
-            log,
+            retry,
+            sink,
             step,
         )
         .await
     } else {
         let dest_file = resolve_dest_path(src, &dest_root, watch_path, preserve_structure)?;
-        copy_one_file(src, &dest_file, overwrite, verify_integrity, global, log, step).await
+        copy_one_file(src, &dest_file, overwrite, verify_integrity, retry, sink, step).await
     }
 }
 
@@ -56,12 +55,12 @@ async fn copy_one_file(
     dest: &Path,
     overwrite: bool,
     verify_integrity: bool,
-    global: &Global,
-    log: Arc<Logger>,
+    retry: &RetryConfig,
+    sink: &ActionSink,
     step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     if dest.exists() && !overwrite {
-        log.warn(format!(
+        sink.warn(step.0, step.1, format!(
             "copy スキップ (overwrite=false で既存): {}",
             dest.display()
         ));
@@ -78,8 +77,8 @@ async fn copy_one_file(
         })?;
     }
 
-    let max_attempts = global.retry_count.saturating_add(1);
-    let interval = Duration::from_millis(global.retry_interval_ms);
+    let max_attempts = retry.count.saturating_add(1);
+    let interval = Duration::from_millis(retry.interval_ms);
 
     for attempt in 1..=max_attempts {
         match try_copy_once(src, dest, verify_integrity).await {
@@ -87,7 +86,7 @@ async fn copy_one_file(
                 let hash_suffix = maybe_hash
                     .map(|h| format!("  [BLAKE3: {h}]"))
                     .unwrap_or_default();
-                log.log_action_ok(step.0, step.1, format!(
+                sink.ok(step.0, step.1, format!(
                     "コピー完了: {} → {}{}",
                     src.display(), dest.display(), hash_suffix
                 ));
@@ -96,17 +95,16 @@ async fn copy_one_file(
             Err(e) => {
                 let _ = tokio::fs::remove_file(dest).await;
                 if attempt < max_attempts {
-                    log.warn(format!(
+                    sink.warn(step.0, step.1, format!(
                         "copy 失敗 ({}回目/{}回): {} → {}: {} (再試行)",
                         attempt, max_attempts, src.display(), dest.display(), e
                     ));
                     tokio::time::sleep(interval).await;
                 } else {
-                    log.error(format!(
+                    return Err(AppError::Action(format!(
                         "copy 最終失敗 ({}回試行): {} → {}: {}",
                         max_attempts, src.display(), dest.display(), e
-                    ));
-                    return Err(e);
+                    )));
                 }
             }
         }
@@ -115,6 +113,7 @@ async fn copy_one_file(
 }
 
 /// ディレクトリ再帰コピー。配下ファイルを 1 つずつ copy_one_file に流す。
+#[allow(clippy::too_many_arguments)]
 async fn copy_directory_recursive(
     src_dir: &Path,
     dest_root: &Path,
@@ -122,8 +121,8 @@ async fn copy_directory_recursive(
     overwrite: bool,
     preserve_structure: bool,
     verify_integrity: bool,
-    global: &Global,
-    log: Arc<Logger>,
+    retry: &RetryConfig,
+    sink: &ActionSink,
     step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     let folder_dest = if preserve_structure {
@@ -153,7 +152,7 @@ async fn copy_directory_recursive(
             .strip_prefix(src_dir)
             .map_err(|e| AppError::Action(format!("配下相対パス解決失敗: {}", e)))?;
         let entry_dest = folder_dest.join(rel);
-        copy_one_file(&entry, &entry_dest, overwrite, verify_integrity, global, Arc::clone(&log), step).await?;
+        copy_one_file(&entry, &entry_dest, overwrite, verify_integrity, retry, sink, step).await?;
     }
 
     Ok(Some(folder_dest))
@@ -162,24 +161,14 @@ async fn copy_directory_recursive(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ActionType, Global, LogLevel, LogRotation};
+    use crate::config::{ActionType, LogRotation};
+    use crate::logger::Logger;
     use std::io::Write;
+    use std::sync::Arc;
     use tempfile::tempdir;
 
-    fn make_global(retry_count: u32) -> Global {
-        let dir = tempdir().unwrap();
-        Global {
-            log_level: LogLevel::Info,
-            log_dir: dir.path().to_str().unwrap().to_string(),
-            log_file_name: "test.log".to_string(),
-            log_rotation: LogRotation::Never,
-            retry_count,
-            retry_interval_ms: 10,
-            log_to_console: false,
-            log_to_file: false,
-            terminal_log_level: None,
-            file_log_level: None,
-        }
+    fn make_retry(count: u32) -> RetryConfig {
+        RetryConfig { count, interval_ms: 10 }
     }
 
     fn make_copy_action(
@@ -211,23 +200,16 @@ mod tests {
         f.write_all(body).unwrap();
     }
 
-    fn make_logger() -> Arc<Logger> {
+    fn make_sink() -> ActionSink {
         let dir = tempdir().unwrap();
-        let global = Global {
-            log_level: LogLevel::Info,
-            log_dir: dir.path().to_str().unwrap().to_string(),
-            log_file_name: "test.log".to_string(),
-            log_rotation: LogRotation::Never,
-            retry_count: 0,
-            retry_interval_ms: 0,
-            log_to_console: false,
-            log_to_file: false,
-            terminal_log_level: None,
-            file_log_level: None,
-        };
+        let (logger, _) = Logger::for_action(
+            dir.path().to_str().unwrap().to_string(),
+            "test.log".to_string(),
+            LogRotation::Never,
+        )
+        .unwrap();
         std::mem::forget(dir);
-        let (logger, _) = Logger::new(&global).unwrap();
-        Arc::new(logger)
+        ActionSink::new(Arc::new(logger), None)
     }
 
     #[tokio::test]
@@ -238,10 +220,10 @@ mod tests {
         write_file(&src, b"hello");
 
         let action = make_copy_action(dest.path().to_str().unwrap(), false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         let dest_file = dest.path().join("a.txt");
         assert!(dest_file.exists());
         assert_eq!(result, Some(dest_file));
@@ -255,10 +237,10 @@ mod tests {
         write_file(&src, b"hello");
 
         let action = make_copy_action(dest.path().to_str().unwrap(), false, true, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert!(dest.path().join("sub/deep/a.txt").exists());
     }
 
@@ -272,10 +254,10 @@ mod tests {
         write_file(&dest_file, b"old");
 
         let action = make_copy_action(dest.path().to_str().unwrap(), false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert_eq!(result, None);
         assert_eq!(std::fs::read(&dest_file).unwrap(), b"old");
     }
@@ -290,10 +272,10 @@ mod tests {
         write_file(&dest_file, b"old");
 
         let action = make_copy_action(dest.path().to_str().unwrap(), true, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert_eq!(std::fs::read(&dest_file).unwrap(), b"new");
     }
 
@@ -305,10 +287,10 @@ mod tests {
         write_file(&src, b"some payload to hash");
 
         let action = make_copy_action(dest.path().to_str().unwrap(), false, false, true);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert!(result.is_some());
         assert!(dest.path().join("a.txt").exists());
     }
@@ -322,10 +304,10 @@ mod tests {
         write_file(&src_dir.join("sub/b.txt"), b"b");
 
         let action = make_copy_action(dest.path().to_str().unwrap(), false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src_dir, watch.path(), "");
 
-        let result = execute(&action, &src_dir, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src_dir, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert_eq!(result, Some(dest.path().join("mydir")));
         assert!(dest.path().join("mydir/a.txt").exists());
         assert!(dest.path().join("mydir/sub/b.txt").exists());
@@ -343,10 +325,10 @@ mod tests {
             dest_root.path().to_str().unwrap()
         );
         let action = make_copy_action(&dest_template, false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         let dest_path = result.expect("コピー成功");
 
         assert!(dest_path.exists(), "コピー先ファイルが存在しない: {}", dest_path.display());
@@ -368,10 +350,10 @@ mod tests {
 
         let dest_template = format!("{}/{{BaseName}}", dest.path().to_str().unwrap());
         let action = make_copy_action(&dest_template, false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         let expected = dest.path().join("a").join("a.txt");
         assert_eq!(result.as_deref(), Some(expected.as_path()));
         assert!(expected.exists());

--- a/cat-watcher/src/actions/execute.rs
+++ b/cat-watcher/src/actions/execute.rs
@@ -1,17 +1,15 @@
-use std::sync::Arc;
-
 use std::process::Stdio;
 
-use crate::config::{ActionConfig, Global};
+use crate::config::ActionConfig;
 use crate::error::AppError;
-use crate::logger::Logger;
 use crate::placeholder::{expand_placeholders, PlaceholderContext};
+
+use super::ActionSink;
 
 pub async fn execute(
     action: &ActionConfig,
     ctx: &PlaceholderContext,
-    _global: &Global,
-    log: Arc<Logger>,
+    sink: &ActionSink,
     step: (usize, usize),
 ) -> Result<(), AppError> {
     let program = action
@@ -49,31 +47,17 @@ pub async fn execute(
         ))
     })?;
 
-    log.log_action_ok(step.0, step.1, "起動");
+    sink.ok(step.0, step.1, "起動".to_string());
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ActionType, Global, LogLevel, LogRotation};
+    use crate::config::{ActionType, LogRotation};
+    use crate::logger::Logger;
+    use std::sync::Arc;
     use tempfile::tempdir;
-
-    fn make_global() -> Global {
-        let dir = tempdir().unwrap();
-        Global {
-            log_level: LogLevel::Info,
-            log_dir: dir.path().to_str().unwrap().to_string(),
-            log_file_name: "test.log".to_string(),
-            log_rotation: LogRotation::Never,
-            retry_count: 0,
-            retry_interval_ms: 0,
-            log_to_console: false,
-            log_to_file: false,
-            terminal_log_level: None,
-            file_log_level: None,
-        }
-    }
 
     fn make_action(program: &str, args: Vec<&str>, working_dir: &str) -> ActionConfig {
         ActionConfig {
@@ -95,23 +79,16 @@ mod tests {
         PlaceholderContext::new(src, watch, "")
     }
 
-    fn make_logger() -> Arc<Logger> {
+    fn make_sink() -> ActionSink {
         let dir = tempdir().unwrap();
-        let global = Global {
-            log_level: LogLevel::Info,
-            log_dir: dir.path().to_str().unwrap().to_string(),
-            log_file_name: "test.log".to_string(),
-            log_rotation: LogRotation::Never,
-            retry_count: 0,
-            retry_interval_ms: 0,
-            log_to_console: false,
-            log_to_file: false,
-            terminal_log_level: None,
-            file_log_level: None,
-        };
+        let (logger, _) = Logger::for_action(
+            dir.path().to_str().unwrap().to_string(),
+            "test.log".to_string(),
+            LogRotation::Never,
+        )
+        .unwrap();
         std::mem::forget(dir);
-        let (logger, _) = Logger::new(&global).unwrap();
-        Arc::new(logger)
+        ActionSink::new(Arc::new(logger), None)
     }
 
     #[cfg(target_os = "windows")]
@@ -122,8 +99,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd.exe", vec!["/C", "echo hello"], "");
-        let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
+        assert!(execute(&action, &ctx, &make_sink(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -134,8 +110,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd.exe", vec!["/C", "echo {FullName}"], "");
-        let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
+        assert!(execute(&action, &ctx, &make_sink(), (1, 1)).await.is_ok());
     }
 
     #[cfg(target_os = "windows")]
@@ -146,8 +121,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("cmd.exe", vec!["/C", "echo hi"], dir.path().to_str().unwrap());
-        let global = make_global();
-        assert!(execute(&action, &ctx, &global, make_logger(), (1, 1)).await.is_ok());
+        assert!(execute(&action, &ctx, &make_sink(), (1, 1)).await.is_ok());
     }
 
     #[tokio::test]
@@ -157,8 +131,7 @@ mod tests {
         std::fs::write(&src, b"x").unwrap();
         let ctx = make_ctx(&src, dir.path());
         let action = make_action("nonexistent_program_xyz.exe", vec![], "");
-        let global = make_global();
-        let result = execute(&action, &ctx, &global, make_logger(), (1, 1)).await;
+        let result = execute(&action, &ctx, &make_sink(), (1, 1)).await;
         assert!(result.is_err());
     }
 }

--- a/cat-watcher/src/actions/mod.rs
+++ b/cat-watcher/src/actions/mod.rs
@@ -7,76 +7,140 @@ pub mod r#move;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::config::{ActionConfig, ActionType, Global};
+use crate::config::{ActionConfig, ActionType, RetryConfig};
 use crate::error::AppError;
 use crate::logger::Logger;
 use crate::placeholder::{expand_placeholders, PlaceholderContext};
 
-/// global ロガーとルール別ロガーの両方に同じエントリを送る。
-macro_rules! log_all {
-    ($log:expr, $rule_log:expr, $method:ident ( $($arg:expr),* )) => {{
-        $log.$method($($arg.clone()),*);
-        if let Some(rl) = $rule_log {
-            rl.$method($($arg),*);
+/// アクション結果（開始・成功・失敗・警告・補足）を
+/// system ロガー（ターミナル表示用）と action ロガー（ファイル記録用）の
+/// 両系統へ送るファンアウト。system 側はコンソールに出るがシステムログ
+/// ファイルには書かれない（writer_task の System 分岐が Action 系を捨てる）。
+pub struct ActionSink {
+    system: Arc<Logger>,
+    action: Option<Arc<Logger>>,
+}
+
+impl ActionSink {
+    pub fn new(system: Arc<Logger>, action: Option<Arc<Logger>>) -> Self {
+        Self { system, action }
+    }
+
+    /// ステップ開始行（[ACTION] / "N. copy"）。
+    pub fn action_start(&self, index: usize, total: usize, action_type: &str, detail: String) {
+        self.system.log_action(index, total, action_type, detail.clone());
+        if let Some(a) = &self.action {
+            a.log_action(index, total, action_type, detail);
         }
-    }};
+    }
+
+    /// ステップ成功（[OK] / "N. OK"）。
+    pub fn ok(&self, index: usize, total: usize, msg: String) {
+        self.system.log_action_ok(index, total, msg.clone());
+        if let Some(a) = &self.action {
+            a.log_action_ok(index, total, msg);
+        }
+    }
+
+    /// ステップ失敗（[ERROR] / "N. ERR"）。
+    pub fn err(&self, index: usize, total: usize, msg: String) {
+        self.system.log_action_err(index, total, msg.clone());
+        if let Some(a) = &self.action {
+            a.log_action_err(index, total, msg);
+        }
+    }
+
+    /// ステップ警告（スキップ・リトライ等。[WARN] / "N. WARN"）。
+    pub fn warn(&self, index: usize, total: usize, msg: String) {
+        self.system.log_action_warn(index, total, msg.clone());
+        if let Some(a) = &self.action {
+            a.log_action_warn(index, total, msg);
+        }
+    }
+
+    /// 補足情報（別ボリュームへの copy+delete 等。[INFO] / "N. --"）。
+    pub fn note(&self, index: usize, total: usize, msg: String) {
+        self.system.log_action_note(index, total, msg.clone());
+        if let Some(a) = &self.action {
+            a.log_action_note(index, total, msg);
+        }
+    }
 }
 
 /// 1 つの監視イベントに対して、ルールの actions を順に実行する。
 /// アクション間で PlaceholderContext を保持し、copy/move 完了後に {Destination} を更新する。
+///
+/// `log` は system ロガー（ターミナル表示）、`action_log` はルール別アクションログ
+/// （ファイル）。アクション失敗エラーは両系統へ送るが、システムログ**ファイル**には
+/// 残らない（アクション失敗は action ログにのみ記録する方針）。
 pub async fn execute_chain(
     actions: &[ActionConfig],
     src: &Path,
     watch_path: &Path,
-    global: &Global,
+    retry: &RetryConfig,
     log: Arc<Logger>,
-    rule_log: Option<Arc<Logger>>,
+    action_log: Option<Arc<Logger>>,
 ) -> Result<(), AppError> {
+    let sink = ActionSink::new(log, action_log);
     let mut ctx = PlaceholderContext::new(src, watch_path, "");
     let total = actions.len();
 
     for (i, action) in actions.iter().enumerate() {
         let index = i + 1;
         let step = (index, total);
-        match action.type_ {
+
+        let result: Result<Option<std::path::PathBuf>, AppError> = match action.type_ {
             ActionType::Copy => {
                 let dest_str = action.destination.as_deref().unwrap_or("");
-                let detail = format!("{} → {}", src.display(), dest_str);
-                log_all!(log, rule_log.as_deref(), log_action(index, total, "copy", detail));
-                let result = copy::execute(action, src, &ctx, global, Arc::clone(&log), step).await?;
-                if let Some(dest_file) = result {
-                    ctx.destination = dest_file.to_string_lossy().replace('\\', "/");
-                }
+                let overwrite = action.overwrite.unwrap_or(false);
+                let detail = format!("destination={dest_str}  overwrite={overwrite}");
+                sink.action_start(index, total, "copy", detail);
+                copy::execute(action, src, &ctx, retry, &sink, step).await
             }
             ActionType::Move => {
                 let dest_str = action.destination.as_deref().unwrap_or("");
-                let detail = format!("{} → {}", src.display(), dest_str);
-                log_all!(log, rule_log.as_deref(), log_action(index, total, "move", detail));
-                let result = r#move::execute(action, src, &ctx, global, Arc::clone(&log), step).await?;
-                if let Some(dest_file) = result {
-                    ctx.destination = dest_file.to_string_lossy().replace('\\', "/");
-                }
+                let overwrite = action.overwrite.unwrap_or(false);
+                let detail = format!("destination={dest_str}  overwrite={overwrite}");
+                sink.action_start(index, total, "move", detail);
+                r#move::execute(action, src, &ctx, retry, &sink, step).await
             }
             ActionType::Command => {
                 let shell = action.shell.as_deref().unwrap_or("");
                 let cmd = action.command.as_deref().unwrap_or("");
-                let detail = format!("shell={shell}  cmd={cmd}");
-                log_all!(log, rule_log.as_deref(), log_action(index, total, "command", detail));
-                command::execute(action, &ctx, global, Arc::clone(&log), step).await?;
+                let detail = format!("shell={shell}  command={cmd}");
+                sink.action_start(index, total, "command", detail);
+                command::execute(action, &ctx, &sink, step).await.map(|_| None)
             }
             ActionType::Execute => {
                 let program = action.program.as_deref().unwrap_or("");
                 let args = action.args.as_deref().unwrap_or(&[]);
                 let args_str = args.join(" ");
                 let detail = format!("{program} {args_str}").trim_end().to_string();
-                log_all!(log, rule_log.as_deref(), log_action(index, total, "execute", detail));
-                execute::execute(action, &ctx, global, Arc::clone(&log), step).await?;
+                sink.action_start(index, total, "execute", detail);
+                execute::execute(action, &ctx, &sink, step).await.map(|_| None)
             }
             ActionType::Log => {
                 let raw = action.message.as_deref().unwrap_or("");
-                let msg = expand_placeholders(raw, &ctx)?;
-                log_all!(log, rule_log.as_deref(), log_action(index, total, "log", ""));
-                log_all!(log, rule_log.as_deref(), log_action_ok(index, total, msg));
+                sink.action_start(index, total, "log", String::new());
+                match expand_placeholders(raw, &ctx) {
+                    Ok(msg) => {
+                        sink.ok(index, total, msg);
+                        Ok(None)
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+        };
+
+        match result {
+            Ok(Some(dest_file)) => {
+                ctx.destination = dest_file.to_string_lossy().replace('\\', "/");
+            }
+            Ok(None) => {}
+            Err(e) => {
+                // アクション失敗は action ログ＋ターミナルに記録（システムログには残さない）
+                sink.err(index, total, format!("{e}"));
+                return Err(e);
             }
         }
     }

--- a/cat-watcher/src/actions/move.rs
+++ b/cat-watcher/src/actions/move.rs
@@ -1,16 +1,15 @@
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
-use crate::config::{ActionConfig, Global};
+use crate::config::{ActionConfig, RetryConfig};
 use crate::error::AppError;
-use crate::logger::Logger;
 use crate::placeholder::PlaceholderContext;
 
 use super::common::{
     expand_action_destination, resolve_dest_path, try_copy_once, walk_files,
 };
+use super::ActionSink;
 
 /// move アクションのエントリポイント。
 /// 戻り値:
@@ -21,8 +20,8 @@ pub async fn execute(
     action: &ActionConfig,
     src: &Path,
     ctx: &PlaceholderContext,
-    global: &Global,
-    log: Arc<Logger>,
+    retry: &RetryConfig,
+    sink: &ActionSink,
     step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     let dest_root = expand_action_destination(action, ctx)?;
@@ -40,14 +39,14 @@ pub async fn execute(
             overwrite,
             preserve_structure,
             verify_integrity,
-            global,
-            log,
+            retry,
+            sink,
             step,
         )
         .await
     } else {
         let dest_file = resolve_dest_path(src, &dest_root, watch_path, preserve_structure)?;
-        move_one_file(src, &dest_file, overwrite, verify_integrity, global, log, step).await
+        move_one_file(src, &dest_file, overwrite, verify_integrity, retry, sink, step).await
     }
 }
 
@@ -57,12 +56,12 @@ async fn move_one_file(
     dest: &Path,
     overwrite: bool,
     verify_integrity: bool,
-    global: &Global,
-    log: Arc<Logger>,
+    retry: &RetryConfig,
+    sink: &ActionSink,
     step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     if dest.exists() && !overwrite {
-        log.warn(format!(
+        sink.warn(step.0, step.1, format!(
             "move スキップ (overwrite=false で既存): {}",
             dest.display()
         ));
@@ -82,11 +81,11 @@ async fn move_one_file(
     // まず rename を試みる（同一ボリューム）
     match tokio::fs::rename(src, dest).await {
         Ok(()) => {
-            log.log_action_ok(step.0, step.1, format!("移動完了 (rename): {} → {}", src.display(), dest.display()));
+            sink.ok(step.0, step.1, format!("移動完了 (rename): {} → {}", src.display(), dest.display()));
             return Ok(Some(dest.to_path_buf()));
         }
         Err(e) if is_cross_device(&e) => {
-            log.info(format!(
+            sink.note(step.0, step.1, format!(
                 "異ボリューム検出: copy フォールバックで移動します {} → {}",
                 src.display(),
                 dest.display()
@@ -102,8 +101,8 @@ async fn move_one_file(
     }
 
     // cross-device フォールバック: コピー + 元ファイル削除（リトライあり）
-    let max_attempts = global.retry_count.saturating_add(1);
-    let interval = Duration::from_millis(global.retry_interval_ms);
+    let max_attempts = retry.count.saturating_add(1);
+    let interval = Duration::from_millis(retry.interval_ms);
 
     for attempt in 1..=max_attempts {
         match try_copy_once(src, dest, verify_integrity).await {
@@ -118,7 +117,7 @@ async fn move_one_file(
                 let hash_suffix = maybe_hash
                     .map(|h| format!("  [BLAKE3: {h}]"))
                     .unwrap_or_default();
-                log.log_action_ok(step.0, step.1, format!(
+                sink.ok(step.0, step.1, format!(
                     "移動完了 (copy+delete): {} → {}{}",
                     src.display(),
                     dest.display(),
@@ -129,17 +128,16 @@ async fn move_one_file(
             Err(e) => {
                 let _ = tokio::fs::remove_file(dest).await;
                 if attempt < max_attempts {
-                    log.warn(format!(
+                    sink.warn(step.0, step.1, format!(
                         "move 失敗 ({}回目/{}回): {} → {}: {} (再試行)",
                         attempt, max_attempts, src.display(), dest.display(), e
                     ));
                     tokio::time::sleep(interval).await;
                 } else {
-                    log.error(format!(
+                    return Err(AppError::Action(format!(
                         "move 最終失敗 ({}回試行): {} → {}: {}",
                         max_attempts, src.display(), dest.display(), e
-                    ));
-                    return Err(e);
+                    )));
                 }
             }
         }
@@ -148,6 +146,7 @@ async fn move_one_file(
 }
 
 /// ディレクトリ再帰移動。配下ファイルを 1 つずつ move_one_file に流し、最後に空ディレクトリを削除する。
+#[allow(clippy::too_many_arguments)]
 async fn move_directory_recursive(
     src_dir: &Path,
     dest_root: &Path,
@@ -155,8 +154,8 @@ async fn move_directory_recursive(
     overwrite: bool,
     preserve_structure: bool,
     verify_integrity: bool,
-    global: &Global,
-    log: Arc<Logger>,
+    retry: &RetryConfig,
+    sink: &ActionSink,
     step: (usize, usize),
 ) -> Result<Option<PathBuf>, AppError> {
     let folder_dest = if preserve_structure {
@@ -186,7 +185,7 @@ async fn move_directory_recursive(
             .strip_prefix(src_dir)
             .map_err(|e| AppError::Action(format!("配下相対パス解決失敗: {}", e)))?;
         let entry_dest = folder_dest.join(rel);
-        move_one_file(entry, &entry_dest, overwrite, verify_integrity, global, Arc::clone(&log), step).await?;
+        move_one_file(entry, &entry_dest, overwrite, verify_integrity, retry, sink, step).await?;
     }
 
     tokio::fs::remove_dir_all(src_dir).await.map_err(|e| {
@@ -224,24 +223,14 @@ fn windows_is_cross_device(_e: &std::io::Error) -> bool {
 mod tests {
     use super::*;
     use super::super::common::hash_file_blake3;
-    use crate::config::{ActionType, Global, LogLevel, LogRotation};
+    use crate::config::{ActionType, LogRotation};
+    use crate::logger::Logger;
     use std::io::Write;
+    use std::sync::Arc;
     use tempfile::tempdir;
 
-    fn make_global(retry_count: u32) -> Global {
-        let dir = tempdir().unwrap();
-        Global {
-            log_level: LogLevel::Info,
-            log_dir: dir.path().to_str().unwrap().to_string(),
-            log_file_name: "test.log".to_string(),
-            log_rotation: LogRotation::Never,
-            retry_count,
-            retry_interval_ms: 10,
-            log_to_console: false,
-            log_to_file: false,
-            terminal_log_level: None,
-            file_log_level: None,
-        }
+    fn make_retry(count: u32) -> RetryConfig {
+        RetryConfig { count, interval_ms: 10 }
     }
 
     fn make_move_action(
@@ -272,23 +261,16 @@ mod tests {
         std::fs::File::create(path).unwrap().write_all(body).unwrap();
     }
 
-    fn make_logger() -> Arc<Logger> {
+    fn make_sink() -> ActionSink {
         let dir = tempdir().unwrap();
-        let global = Global {
-            log_level: LogLevel::Info,
-            log_dir: dir.path().to_str().unwrap().to_string(),
-            log_file_name: "test.log".to_string(),
-            log_rotation: LogRotation::Never,
-            retry_count: 0,
-            retry_interval_ms: 0,
-            log_to_console: false,
-            log_to_file: false,
-            terminal_log_level: None,
-            file_log_level: None,
-        };
+        let (logger, _) = Logger::for_action(
+            dir.path().to_str().unwrap().to_string(),
+            "test.log".to_string(),
+            LogRotation::Never,
+        )
+        .unwrap();
         std::mem::forget(dir);
-        let (logger, _) = Logger::new(&global).unwrap();
-        Arc::new(logger)
+        ActionSink::new(Arc::new(logger), None)
     }
 
     #[tokio::test]
@@ -299,10 +281,10 @@ mod tests {
         write_file(&src, b"hello");
 
         let action = make_move_action(dest.path().to_str().unwrap(), false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert_eq!(result, Some(dest.path().join("a.txt")));
         assert!(dest.path().join("a.txt").exists());
         assert!(!src.exists(), "元ファイルが残っている");
@@ -317,10 +299,10 @@ mod tests {
         write_file(&dest.path().join("a.txt"), b"old");
 
         let action = make_move_action(dest.path().to_str().unwrap(), false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert_eq!(result, None);
         assert_eq!(std::fs::read(dest.path().join("a.txt")).unwrap(), b"old");
         assert!(src.exists(), "スキップ時は元ファイルを保持");
@@ -335,10 +317,10 @@ mod tests {
         write_file(&dest.path().join("a.txt"), b"old");
 
         let action = make_move_action(dest.path().to_str().unwrap(), true, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert_eq!(std::fs::read(dest.path().join("a.txt")).unwrap(), b"new");
         assert!(!src.exists());
     }
@@ -351,10 +333,10 @@ mod tests {
         write_file(&src, b"hello");
 
         let action = make_move_action(dest.path().to_str().unwrap(), false, true, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert!(dest.path().join("sub/deep/a.txt").exists());
         assert!(!src.exists());
     }
@@ -368,10 +350,10 @@ mod tests {
         write_file(&src_dir.join("sub/b.txt"), b"b");
 
         let action = make_move_action(dest.path().to_str().unwrap(), false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src_dir, watch.path(), "");
 
-        let result = execute(&action, &src_dir, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src_dir, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert_eq!(result, Some(dest.path().join("mydir")));
         assert!(dest.path().join("mydir/a.txt").exists());
         assert!(dest.path().join("mydir/sub/b.txt").exists());
@@ -386,10 +368,10 @@ mod tests {
         write_file(&src, b"payload for hash");
 
         let action = make_move_action(dest.path().to_str().unwrap(), false, false, true);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         assert!(result.is_some());
         assert!(!src.exists());
     }
@@ -406,10 +388,10 @@ mod tests {
             dest_root.path().to_str().unwrap()
         );
         let action = make_move_action(&dest_template, false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await.unwrap();
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await.unwrap();
         let dest_path = result.expect("移動成功");
         assert!(dest_path.exists());
         assert_eq!(dest_path.file_name().unwrap(), "a.txt");
@@ -423,10 +405,10 @@ mod tests {
         let src = watch.path().join("nonexistent.txt");
 
         let action = make_move_action(dest.path().to_str().unwrap(), false, false, false);
-        let global = make_global(0);
+        let retry = make_retry(0);
         let ctx = PlaceholderContext::new(&src, watch.path(), "");
 
-        let result = execute(&action, &src, &ctx, &global, make_logger(), (1, 1)).await;
+        let result = execute(&action, &src, &ctx, &retry, &make_sink(), (1, 1)).await;
         assert!(result.is_err(), "存在しないファイルの move はエラー");
     }
 

--- a/cat-watcher/src/config.rs
+++ b/cat-watcher/src/config.rs
@@ -2009,4 +2009,51 @@ mod tests {
 		let result = validate_rules_config(&config);
 		assert!(result.is_ok());
 	}
+
+	// =========================================================
+	// テンプレート TOML パーステスト
+	// Windows バックスラッシュパスが TOML として正しくパースできること
+	// =========================================================
+
+	#[test]
+	fn test_global_template_is_valid_toml() {
+		use crate::templates::GLOBAL_TOML;
+		let result = toml::from_str::<toml::Value>(GLOBAL_TOML);
+		assert!(
+			result.is_ok(),
+			"GLOBAL_TOML テンプレートが TOML としてパースできません: {:?}",
+			result.err()
+		);
+	}
+
+	#[test]
+	fn test_global_template_windows_path_preserved() {
+		use crate::templates::GLOBAL_TOML;
+		let val: toml::Value = toml::from_str(GLOBAL_TOML).unwrap();
+		let dir = val["system_log"]["dir"].as_str().unwrap();
+		assert_eq!(dir, r"C:\logs", "system_log.dir のパスが正しく保持されていません");
+	}
+
+	#[test]
+	fn test_rules_template_is_valid_toml() {
+		use crate::templates::RULES_TOML;
+		let result = toml::from_str::<toml::Value>(RULES_TOML);
+		assert!(
+			result.is_ok(),
+			"RULES_TOML テンプレートが TOML としてパースできません: {:?}",
+			result.err()
+		);
+	}
+
+	#[test]
+	fn test_rules_template_windows_path_preserved() {
+		use crate::templates::RULES_TOML;
+		let val: toml::Value = toml::from_str(RULES_TOML).unwrap();
+		let path = val["rules"][0]["watch"]["path"].as_str().unwrap();
+		assert_eq!(path, r"C:\監視フォルダ", "rules[0].watch.path のパスが正しく保持されていません");
+		let detect_dir = val["rules"][0]["log"]["detect"]["dir"].as_str().unwrap();
+		assert_eq!(detect_dir, r"C:\logs", "rules[0].log.detect.dir のパスが正しく保持されていません");
+		let action_dir = val["rules"][0]["log"]["action"]["dir"].as_str().unwrap();
+		assert_eq!(action_dir, r"C:\logs", "rules[0].log.action.dir のパスが正しく保持されていません");
+	}
 }

--- a/cat-watcher/src/config.rs
+++ b/cat-watcher/src/config.rs
@@ -94,8 +94,10 @@ impl_case_insensitive_deserialize!(ActionType,
 );
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GlobalConfig {
-    pub global: Global,
+    pub retry: RetryConfig,
+    pub system_log: SystemLogConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -107,31 +109,46 @@ fn default_true() -> bool {
     true
 }
 
+/// リトライ設定（copy / move アクション用）。
 #[derive(Debug, Clone, Deserialize)]
-pub struct Global {
-    pub log_level: LogLevel,
-    pub log_dir: String,
-    pub log_file_name: String,
-    pub log_rotation: LogRotation,
-    pub retry_count: u32,
-    pub retry_interval_ms: u64,
-    #[serde(default = "default_true")]
-    pub log_to_console: bool,
-    #[serde(default = "default_true")]
-    pub log_to_file: bool,
-    /// ターミナル出力専用ログレベル。省略時は log_level を使用。
-    pub terminal_log_level: Option<LogLevel>,
-    /// ファイル出力専用ログレベル。省略時は log_level を使用。
-    pub file_log_level: Option<LogLevel>,
+#[serde(deny_unknown_fields)]
+pub struct RetryConfig {
+    pub count: u32,
+    pub interval_ms: u64,
 }
 
+/// システムログ設定（プログラム全体の起動日誌）。
 #[derive(Debug, Clone, Deserialize)]
-pub struct RuleLog {
+#[serde(deny_unknown_fields)]
+pub struct SystemLogConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
-    pub log_dir: Option<String>,
-    pub log_file_name: Option<String>,
-    pub log_rotation: Option<LogRotation>,
+    pub dir: String,
+    pub file_name: String,
+    pub rotation: LogRotation,
+    pub level: LogLevel,
+    /// コンソール出力 ON/OFF（ターミナル再設計までの暫定置き場）。
+    #[serde(default = "default_true")]
+    pub console: bool,
+}
+
+/// ルール別ログ設定。検知ログ・アクションログをそれぞれ個別指定する。
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuleLog {
+    pub detect: Option<RuleLogTarget>,
+    pub action: Option<RuleLogTarget>,
+}
+
+/// 検知ログ / アクションログ共通の出力先設定。
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuleLogTarget {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    pub dir: String,
+    pub file_name: String,
+    pub rotation: LogRotation,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -206,7 +223,7 @@ pub fn load_global_config(path: &Path) -> Result<GlobalConfig, AppError> {
 	let content = std::fs::read_to_string(path)?;
 	let mut config: GlobalConfig = toml::from_str(&content)
 							.map_err(|e| AppError::TomlParse(e.to_string()))?;
-	config.global.log_dir = expand_tilde(&config.global.log_dir);
+	config.system_log.dir = expand_tilde(&config.system_log.dir);
 	Ok(config)
 }
 
@@ -221,7 +238,12 @@ pub fn load_rules_config(path: &Path) -> Result<RulesConfig, AppError> {
 			action.working_dir = action.working_dir.as_deref().map(expand_tilde);
 		}
 		if let Some(log) = &mut rule.log {
-			log.log_dir = log.log_dir.as_deref().map(expand_tilde);
+			if let Some(detect) = &mut log.detect {
+				detect.dir = expand_tilde(&detect.dir);
+			}
+			if let Some(action) = &mut log.action {
+				action.dir = expand_tilde(&action.dir);
+			}
 		}
 	}
 	Ok(config)
@@ -241,37 +263,51 @@ fn finish_validation(errors: Vec<String>) -> Result<(), AppError> {
 	Err(AppError::Validation(msg.trim_end().to_string()))
 }
 
-pub fn validate_global_config(config: &GlobalConfig) -> Result<(), AppError> {
-	let mut errors = Vec::new();
-
-	let log_dir = &config.global.log_dir;
-	if log_dir.trim().is_empty() {
-		errors.push("log_dir が空文字列です。ログ出力先ディレクトリを定義してください".to_string());
+/// ログの出力先ディレクトリとファイル名を検証する共通ヘルパ。
+/// `label` はエラーメッセージ内のフィールド名（例: "system_log.dir"）。
+fn validate_log_target(
+	dir: &str,
+	file_name: &str,
+	dir_label: &str,
+	file_label: &str,
+	errors: &mut Vec<String>,
+) {
+	if dir.trim().is_empty() {
+		errors.push(format!("{dir_label} が空文字列です。ログ出力先ディレクトリを定義してください"));
 	} else {
-		let dir_path = Path::new(log_dir);
+		let dir_path = Path::new(dir);
 		if !dir_path.exists() {
-			errors.push(format!("log_dir が存在しません: {}", dir_path.display()));
+			errors.push(format!("{dir_label} が存在しません: {}", dir_path.display()));
 		} else if !dir_path.is_dir() {
-			errors.push(format!("log_dir にディレクトリ以外のパスが指定されています: {}", dir_path.display()));
+			errors.push(format!("{dir_label} にディレクトリ以外のパスが指定されています: {}", dir_path.display()));
 		}
 	}
 
-	let log_file_name = &config.global.log_file_name;
-	if log_file_name.trim().is_empty() {
-		errors.push("log_file_name が空文字列です。ファイル名を定義してください".to_string());
+	if file_name.trim().is_empty() {
+		errors.push(format!("{file_label} が空文字列です。ファイル名を定義してください"));
 	} else {
 		let valid_placeholders = ["Date", "DateTime"];
 		let re = regex::Regex::new(r"\{([A-Za-z]+)\}").unwrap();
-		for caps in re.captures_iter(log_file_name) {
+		for caps in re.captures_iter(file_name) {
 			let name = &caps[1];
 			if !valid_placeholders.contains(&name) {
 				errors.push(format!(
-					"log_file_name に使用できないプレースホルダーがあります: {{{name}}}。使用可能なのは {{Date}} と {{DateTime}} のみです"
+					"{file_label} に使用できないプレースホルダーがあります: {{{name}}}。使用可能なのは {{Date}} と {{DateTime}} のみです"
 				));
 			}
 		}
 	}
+}
 
+pub fn validate_global_config(config: &GlobalConfig) -> Result<(), AppError> {
+	let mut errors = Vec::new();
+	validate_log_target(
+		&config.system_log.dir,
+		&config.system_log.file_name,
+		"system_log.dir",
+		"system_log.file_name",
+		&mut errors,
+	);
 	finish_validation(errors)
 }
 
@@ -377,31 +413,26 @@ pub fn validate_rules_config(config: &RulesConfig) -> Result<(), AppError> {
 		}
 
 		if let Some(rule_log) = &rule.log {
-			if rule_log.enabled {
-				if let Some(dir) = &rule_log.log_dir {
-					let p = Path::new(dir);
-					if !p.exists() {
-						errors.push(format!("監視ルール名 {} の log.log_dir が存在しません: {}", rule_id, dir));
-					} else if !p.is_dir() {
-						errors.push(format!("監視ルール名 {} の log.log_dir にディレクトリ以外のパスが指定されています: {}", rule_id, dir));
-					}
+			if let Some(detect) = &rule_log.detect {
+				if detect.enabled {
+					validate_log_target(
+						&detect.dir,
+						&detect.file_name,
+						&format!("監視ルール名 {} の log.detect.dir", rule_id),
+						&format!("監視ルール名 {} の log.detect.file_name", rule_id),
+						&mut errors,
+					);
 				}
-				if let Some(file_name) = &rule_log.log_file_name {
-					if file_name.trim().is_empty() {
-						errors.push(format!("監視ルール名 {} の log.log_file_name が空文字列です", rule_id));
-					} else {
-						let valid_placeholders = ["Date", "DateTime"];
-						let re = regex::Regex::new(r"\{([A-Za-z]+)\}").unwrap();
-						for caps in re.captures_iter(file_name) {
-							let name = &caps[1];
-							if !valid_placeholders.contains(&name) {
-								errors.push(format!(
-									"監視ルール名 {} の log.log_file_name に使用できないプレースホルダーがあります: {{{name}}}",
-									rule_id
-								));
-							}
-						}
-					}
+			}
+			if let Some(action) = &rule_log.action {
+				if action.enabled {
+					validate_log_target(
+						&action.dir,
+						&action.file_name,
+						&format!("監視ルール名 {} の log.action.dir", rule_id),
+						&format!("監視ルール名 {} の log.action.file_name", rule_id),
+						&mut errors,
+					);
 				}
 			}
 		}
@@ -606,24 +637,31 @@ mod tests {
 	// GlobalConfig パーステスト
 	// =========================================================
 
+	fn make_global_toml(dir_path: &str) -> String {
+		format!(r#"
+			[retry]
+			count = 3
+			interval_ms = 1000
+
+			[system_log]
+			enabled = true
+			dir = "{dir_path}"
+			file_name = "system_{{Date}}.log"
+			rotation = "daily"
+			level = "info"
+			console = true
+		"#)
+	}
+
 	#[test]
 	fn test_parse_global_config() {
 		let dir = tempdir().unwrap();
 		let dir_path = sanitize_path(dir.path());
-		let toml_str = format!(r#"
-			[global]
-			log_level = "info"
-			log_dir = "{dir_path}"
-			log_file_name = "app_{{Date}}.log"
-			log_rotation = "daily"
-			retry_count = 3
-			retry_interval_ms = 1000
-			dry_run = false
-		"#);
-		let config: GlobalConfig = toml::from_str(&toml_str).unwrap();
-		assert_eq!(config.global.retry_count, 3);
-		assert_eq!(config.global.retry_interval_ms, 1000);
-		assert_eq!(config.global.log_dir, dir_path);
+		let config: GlobalConfig = toml::from_str(&make_global_toml(&dir_path)).unwrap();
+		assert_eq!(config.retry.count, 3);
+		assert_eq!(config.retry.interval_ms, 1000);
+		assert_eq!(config.system_log.dir, dir_path);
+		assert!(config.system_log.console);
 	}
 
 	#[test]
@@ -632,17 +670,18 @@ mod tests {
 		let dir_path = sanitize_path(dir.path());
 		for level in &["trace", "debug", "info", "warn", "error"] {
 			let toml_str = format!(r#"
-				[global]
-				log_level = "{level}"
-				log_dir = "{dir_path}"
-				log_file_name = "app.log"
-				log_rotation = "daily"
-				retry_count = 1
-				retry_interval_ms = 500
-				dry_run = false
+				[retry]
+				count = 1
+				interval_ms = 500
+
+				[system_log]
+				dir = "{dir_path}"
+				file_name = "system.log"
+				rotation = "daily"
+				level = "{level}"
 			"#);
 			let result: Result<GlobalConfig, _> = toml::from_str(&toml_str);
-			assert!(result.is_ok(), "log_level '{}' のパースに失敗", level);
+			assert!(result.is_ok(), "level '{}' のパースに失敗", level);
 		}
 	}
 
@@ -651,27 +690,66 @@ mod tests {
 		let dir = tempdir().unwrap();
 		let dir_path = sanitize_path(dir.path());
 		let toml_str = format!(r#"
-			[global]
-			log_level = "verbose"
-			log_dir = "{dir_path}"
-			log_file_name = "app.log"
-			log_rotation = "daily"
-			retry_count = 1
-			retry_interval_ms = 500
-			dry_run = false
+			[retry]
+			count = 1
+			interval_ms = 500
+
+			[system_log]
+			dir = "{dir_path}"
+			file_name = "system.log"
+			rotation = "daily"
+			level = "verbose"
 		"#);
 		let result: Result<GlobalConfig, _> = toml::from_str(&toml_str);
 		assert!(result.is_err());
 	}
 
 	#[test]
-	fn test_parse_global_config_missing_field() {
+	fn test_parse_global_config_missing_section() {
+		// system_log セクション自体が無い場合はエラー
+		let toml_str = r#"
+			[retry]
+			count = 1
+			interval_ms = 500
+		"#;
+		let result: Result<GlobalConfig, _> = toml::from_str(toml_str);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_parse_global_config_rejects_legacy_global_section() {
+		// 旧 [global] 形式は deny_unknown_fields で明示エラーになる
 		let toml_str = r#"
 			[global]
 			log_level = "info"
 			log_dir = "logs"
+			log_file_name = "app.log"
+			log_rotation = "daily"
+			retry_count = 3
+			retry_interval_ms = 1000
 		"#;
 		let result: Result<GlobalConfig, _> = toml::from_str(toml_str);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_parse_global_config_rejects_unknown_key() {
+		// system_log に未知キー（旧 log_to_file 等）があればエラー
+		let dir = tempdir().unwrap();
+		let dir_path = sanitize_path(dir.path());
+		let toml_str = format!(r#"
+			[retry]
+			count = 1
+			interval_ms = 500
+
+			[system_log]
+			dir = "{dir_path}"
+			file_name = "system.log"
+			rotation = "daily"
+			level = "info"
+			log_to_file = true
+		"#);
+		let result: Result<GlobalConfig, _> = toml::from_str(&toml_str);
 		assert!(result.is_err());
 	}
 
@@ -679,107 +757,51 @@ mod tests {
 	// GlobalConfig バリデーションテスト
 	// =========================================================
 
+	fn make_global(dir: &str, file_name: &str) -> GlobalConfig {
+		GlobalConfig {
+			retry: RetryConfig { count: 3, interval_ms: 1000 },
+			system_log: SystemLogConfig {
+				enabled: true,
+				dir: dir.to_string(),
+				file_name: file_name.to_string(),
+				rotation: LogRotation::Daily,
+				level: LogLevel::Info,
+				console: true,
+			},
+		}
+	}
+
 	#[test]
 	fn test_validate_global_config_empty_log_dir() {
-		let config = GlobalConfig {
-			global: Global {
-				log_level: LogLevel::Info,
-				log_dir: "   ".to_string(),
-				log_file_name: "app.log".to_string(),
-				log_rotation: LogRotation::Daily,
-				retry_count: 3,
-				retry_interval_ms: 1000,
-				log_to_console: true,
-				log_to_file: true,
-				terminal_log_level: None,
-				file_log_level: None,
-			},
-		};
-		let result = validate_global_config(&config);
-		assert!(result.is_err());
+		let config = make_global("   ", "app.log");
+		assert!(validate_global_config(&config).is_err());
 	}
 
 	#[test]
 	fn test_validate_global_config_dir_not_exist() {
-		let config = GlobalConfig {
-			global: Global {
-				log_level: LogLevel::Info,
-				log_dir: "nonexistent_dir_xyz_12345".to_string(),
-				log_file_name: "app.log".to_string(),
-				log_rotation: LogRotation::Daily,
-				retry_count: 3,
-				retry_interval_ms: 1000,
-				log_to_console: true,
-				log_to_file: true,
-				terminal_log_level: None,
-				file_log_level: None,
-			},
-		};
-		let result = validate_global_config(&config);
-		assert!(result.is_err());
+		let config = make_global("nonexistent_dir_xyz_12345", "app.log");
+		assert!(validate_global_config(&config).is_err());
 	}
 
 	#[test]
 	fn test_validate_global_config_empty_file_name() {
 		let dir = tempdir().unwrap();
-		let config = GlobalConfig {
-			global: Global {
-				log_level: LogLevel::Info,
-				log_dir: dir.path().to_str().unwrap().to_string(),
-				log_file_name: "  ".to_string(),
-				log_rotation: LogRotation::Daily,
-				retry_count: 3,
-				retry_interval_ms: 1000,
-				log_to_console: true,
-				log_to_file: true,
-				terminal_log_level: None,
-				file_log_level: None,
-			},
-		};
-		let result = validate_global_config(&config);
-		assert!(result.is_err());
+		let config = make_global(dir.path().to_str().unwrap(), "  ");
+		assert!(validate_global_config(&config).is_err());
 	}
 
 	#[test]
 	fn test_validate_global_config_invalid_placeholder_in_file_name() {
 		let dir = tempdir().unwrap();
-		let config = GlobalConfig {
-			global: Global {
-				log_level: LogLevel::Info,
-				log_dir: dir.path().to_str().unwrap().to_string(),
-				log_file_name: "app_{Name}.log".to_string(),
-				log_rotation: LogRotation::Daily,
-				retry_count: 3,
-				retry_interval_ms: 1000,
-				log_to_console: true,
-				log_to_file: true,
-				terminal_log_level: None,
-				file_log_level: None,
-			},
-		};
-		let result = validate_global_config(&config);
-		assert!(result.is_err());
+		let config = make_global(dir.path().to_str().unwrap(), "app_{Name}.log");
+		assert!(validate_global_config(&config).is_err());
 	}
 
 	#[test]
 	fn test_validate_global_config_valid() {
 		let dir = tempdir().unwrap();
-		let config = GlobalConfig {
-			global: Global {
-				log_level: LogLevel::Info,
-				log_dir: dir.path().to_str().unwrap().to_string(),
-				log_file_name: "app_{Date}.log".to_string(),
-				log_rotation: LogRotation::Daily,
-				retry_count: 3,
-				retry_interval_ms: 1000,
-				log_to_console: true,
-				log_to_file: true,
-				terminal_log_level: None,
-				file_log_level: None,
-			},
-		};
-		let result = validate_global_config(&config);
-		assert!(result.is_ok());
+		let config = make_global(dir.path().to_str().unwrap(), "app_{Date}.log");
+		assert!(validate_global_config(&config).is_ok());
 	}
 
 	// =========================================================

--- a/cat-watcher/src/logger.rs
+++ b/cat-watcher/src/logger.rs
@@ -7,18 +7,33 @@ use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 
-use crate::config::{Global, LogLevel, LogRotation};
+use crate::config::{LogLevel, LogRotation, SystemLogConfig};
 use crate::error::AppError;
 use unicode_width::UnicodeWidthStr;
 
 const SEPARATOR: &str = "──────────────────────────────────────────────────────────────";
 
-const FILE_LEVEL_WIDTH: usize = 7;
-const FILE_EVENTS_WIDTH: usize = 27;
+/// システムログ level カラムの表示列幅（"ERROR" = 5 列）。
+const SYS_LEVEL_WIDTH: usize = 5;
+/// 検知ログ events カラムの表示列幅。
+const DETECT_EVENTS_WIDTH: usize = 20;
+/// アクションログ ステップカラムの表示列幅（"10. copy" 程度を想定）。
+const ACTION_STEP_WIDTH: usize = 9;
+
+/// ログの種類。`writer_task` がこの種別で整形を分岐する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogKind {
+    /// システムログ（全体1本・ライフサイクル＋システムエラー）。
+    System,
+    /// 検知ログ（ルール別・検知イベントのみ）。
+    Detect,
+    /// アクションログ（ルール別・ブロック構造）。
+    Action,
+}
 
 /// 表示列幅 (East Asian Width, CJK モード) で左寄せパディングする。
 /// Rust 標準の `format!("{:<width$}")` は char 数で揃えるため、
-/// '└' '│' '├' '─' などの罫線記号で表示時に列幅がズレる。
+/// '│' '═' などの罫線記号で表示時に列幅がズレる。
 /// 本プロジェクトは日本語ロケール (CJK) を主用途とするため、
 /// East Asian Ambiguous 文字を 2 列幅として扱う `width_cjk()` を使う。
 fn pad_left_display(s: &str, total_cols: usize) -> String {
@@ -35,33 +50,60 @@ fn pad_left_display(s: &str, total_cols: usize) -> String {
 }
 
 #[derive(Debug)]
+// `total` は将来 "N/total" 表示に使う余地を残して保持する。`Warn` は
+// システム警告用の API として残す（現状の呼び出し元はまだ無い）。
+#[allow(dead_code)]
 pub enum LogEntry {
-    /// イベントブロック開始
+    /// 検知（1ファイル/フォルダのマッチ）。
     Match {
         rule_name: String,
         path: String,
         events: HashSet<crate::config::Event>,
     },
-    /// アクションチェーン ステップ開始
+    /// アクションログのブロック開始セパレータ。
+    ActionBlockStart {
+        path: String,
+        events: HashSet<crate::config::Event>,
+        action_count: usize,
+    },
+    /// アクションチェーン ステップ開始。
     Action {
         index: usize,
         total: usize,
         action_type: String,
         detail: String,
     },
-    /// アクションチェーン ステップ完了
+    /// アクションチェーン ステップ完了（成功）。
     ActionOk {
         index: usize,
         total: usize,
         msg: String,
     },
-    /// 通常情報
+    /// アクションチェーン ステップ失敗。
+    ActionErr {
+        index: usize,
+        total: usize,
+        msg: String,
+    },
+    /// アクションチェーン ステップ警告（スキップ・リトライ等）。
+    ActionWarn {
+        index: usize,
+        total: usize,
+        msg: String,
+    },
+    /// アクションチェーン 補足情報（別ボリュームへの copy+delete 等）。
+    ActionNote {
+        index: usize,
+        total: usize,
+        msg: String,
+    },
+    /// 通常情報。
     Info(String),
-    /// 警告
+    /// 警告。
     Warn(String),
-    /// エラー
+    /// エラー。
     Error(String),
-    /// チャネルをクローズしてロガーを終了させる
+    /// チャネルをクローズしてロガーを終了させる。
     Shutdown,
 }
 
@@ -70,51 +112,67 @@ pub struct Logger {
 }
 
 impl Logger {
-    pub fn new(global: &Global) -> Result<(Self, tokio::task::JoinHandle<()>), AppError> {
+    /// システムログ用ロガー。`allow_console` が false（サービスモード等）なら
+    /// 設定の console によらずコンソール出力を無効化する。
+    pub fn new_system(
+        cfg: &SystemLogConfig,
+        allow_console: bool,
+    ) -> Result<(Self, tokio::task::JoinHandle<()>), AppError> {
         #[cfg(windows)]
         colored::control::set_virtual_terminal(true).ok();
         colored::control::set_override(true);
 
-        let terminal_level = global.terminal_log_level.clone()
-            .unwrap_or_else(|| global.log_level.clone());
-        let file_level = global.file_log_level.clone()
-            .unwrap_or_else(|| global.log_level.clone());
-        let log_dir = global.log_dir.clone();
-        let log_file_name = global.log_file_name.clone();
-        let log_rotation = global.log_rotation.clone();
-        let log_to_console = global.log_to_console;
-        let log_to_file = global.log_to_file;
+        let console = cfg.console && allow_console;
         let (tx, rx) = mpsc::unbounded_channel();
         let handle = tokio::spawn(writer_task(
             rx,
-            log_dir,
-            log_file_name,
-            terminal_level,
-            file_level,
-            log_rotation,
-            log_to_console,
-            log_to_file,
+            cfg.dir.clone(),
+            cfg.file_name.clone(),
+            cfg.rotation.clone(),
+            LogKind::System,
+            cfg.level.clone(),
+            console,
+            cfg.enabled,
         ));
         Ok((Self { tx }, handle))
     }
 
-    /// ルール別ログ専用ロガー（ファイル出力のみ、コンソール出力なし）。
-    pub fn for_rule(
-        log_dir: String,
-        log_file_name: String,
-        log_rotation: LogRotation,
-        file_level: LogLevel,
+    /// 検知ログ用ロガー（ファイル出力のみ・level フィルタなし）。
+    pub fn for_detect(
+        dir: String,
+        file_name: String,
+        rotation: LogRotation,
     ) -> Result<(Self, tokio::task::JoinHandle<()>), AppError> {
         let (tx, rx) = mpsc::unbounded_channel();
         let handle = tokio::spawn(writer_task(
             rx,
-            log_dir,
-            log_file_name,
-            LogLevel::Error, // terminal は無効（log_to_console=false のため参照されない）
-            file_level,
-            log_rotation,
-            false, // log_to_console
-            true,  // log_to_file
+            dir,
+            file_name,
+            rotation,
+            LogKind::Detect,
+            LogLevel::Info,
+            false,
+            true,
+        ));
+        Ok((Self { tx }, handle))
+    }
+
+    /// アクションログ用ロガー（ファイル出力のみ・ブロック構造）。
+    pub fn for_action(
+        dir: String,
+        file_name: String,
+        rotation: LogRotation,
+    ) -> Result<(Self, tokio::task::JoinHandle<()>), AppError> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(writer_task(
+            rx,
+            dir,
+            file_name,
+            rotation,
+            LogKind::Action,
+            LogLevel::Info,
+            false,
+            true,
         ));
         Ok((Self { tx }, handle))
     }
@@ -129,6 +187,19 @@ impl Logger {
             rule_name: rule_name.into(),
             path: path.into(),
             events,
+        });
+    }
+
+    pub fn log_block_start(
+        &self,
+        path: impl Into<String>,
+        events: HashSet<crate::config::Event>,
+        action_count: usize,
+    ) {
+        let _ = self.tx.send(LogEntry::ActionBlockStart {
+            path: path.into(),
+            events,
+            action_count,
         });
     }
 
@@ -155,10 +226,35 @@ impl Logger {
         });
     }
 
+    pub fn log_action_err(&self, index: usize, total: usize, msg: impl Into<String>) {
+        let _ = self.tx.send(LogEntry::ActionErr {
+            index,
+            total,
+            msg: msg.into(),
+        });
+    }
+
+    pub fn log_action_warn(&self, index: usize, total: usize, msg: impl Into<String>) {
+        let _ = self.tx.send(LogEntry::ActionWarn {
+            index,
+            total,
+            msg: msg.into(),
+        });
+    }
+
+    pub fn log_action_note(&self, index: usize, total: usize, msg: impl Into<String>) {
+        let _ = self.tx.send(LogEntry::ActionNote {
+            index,
+            total,
+            msg: msg.into(),
+        });
+    }
+
     pub fn info(&self, msg: impl Into<String>) {
         let _ = self.tx.send(LogEntry::Info(msg.into()));
     }
 
+    #[allow(dead_code)]
     pub fn warn(&self, msg: impl Into<String>) {
         let _ = self.tx.send(LogEntry::Warn(msg.into()));
     }
@@ -196,7 +292,7 @@ async fn open_log_file(path: &PathBuf) -> Option<tokio::fs::File> {
     }
 }
 
-/// アクション種別を最大4文字の短縮名に変換する。
+/// アクション種別を短縮名に変換する（copy/move/cmd/exec/log）。
 fn action_type_short(action_type: &str) -> &str {
     match action_type {
         "copy" => "copy",
@@ -210,67 +306,71 @@ fn action_type_short(action_type: &str) -> &str {
     }
 }
 
-/// ファイルログ用 level カラム文字列（FILE_LEVEL_WIDTH **列** 幅）を生成する。
-/// 全角記号 ('└' '├' '│') を含むため、char 数ではなく表示列幅でパディングする。
-fn file_level_col(entry: &LogEntry) -> String {
+/// システムログに書く level ラベル。書き込み対象外（検知/アクション系）は None。
+fn sys_level_label(entry: &LogEntry) -> Option<&'static str> {
     match entry {
-        LogEntry::Match { .. } => pad_left_display("MATCH", FILE_LEVEL_WIDTH),
-        LogEntry::Action { index, total, action_type, .. } => {
-            let tree = if *index == *total { '└' } else { '├' };
-            let short = action_type_short(action_type);
-            let index_str = index.to_string();
-            // tree ('└'/'├' は CJK で 列幅 2) + index + space(1) + type で
-            // FILE_LEVEL_WIDTH 列に収める。type も CJK 列幅基準で切り詰める。
-            let used_cols = 2 + index_str.len() + 1;
-            let type_max_cols = FILE_LEVEL_WIDTH.saturating_sub(used_cols);
-            let mut type_part = String::new();
-            let mut used = 0usize;
-            for c in short.chars() {
-                let cw = UnicodeWidthStr::width_cjk(c.to_string().as_str());
-                if used + cw > type_max_cols { break; }
-                type_part.push(c);
-                used += cw;
-            }
-            let head = format!("{}{} {}", tree, index_str, type_part);
-            pad_left_display(&head, FILE_LEVEL_WIDTH)
-        }
-        LogEntry::ActionOk { index, total, .. } => {
-            if *index == *total {
-                // 最終ステップ完了: 継続パイプなし
-                pad_left_display("   OK", FILE_LEVEL_WIDTH)
-            } else {
-                // 中間ステップ完了: 継続パイプあり ('│' は列幅 2)
-                pad_left_display("│   OK", FILE_LEVEL_WIDTH)
-            }
-        }
-        LogEntry::Info(_) => pad_left_display("INFO", FILE_LEVEL_WIDTH),
-        LogEntry::Warn(_) => pad_left_display("WARN", FILE_LEVEL_WIDTH),
-        LogEntry::Error(_) => pad_left_display("ERROR", FILE_LEVEL_WIDTH),
-        LogEntry::Shutdown => unreachable!(),
+        LogEntry::Info(_) => Some("INFO"),
+        LogEntry::Warn(_) => Some("WARN"),
+        LogEntry::Error(_) => Some("ERROR"),
+        _ => None,
     }
 }
 
-/// ファイルログ用 events カラム文字列（FILE_EVENTS_WIDTH **列** 幅）を生成する。
-/// MATCH エントリのみイベント名を出力し、それ以外は空白で埋める。
-fn file_events_col(entry: &LogEntry) -> String {
-    let s = match entry {
-        LogEntry::Match { events, .. } => format_events(events),
+/// システムログ content カラム。
+fn sys_content(entry: &LogEntry) -> String {
+    match entry {
+        LogEntry::Info(msg) | LogEntry::Warn(msg) | LogEntry::Error(msg) => msg.clone(),
         _ => String::new(),
-    };
-    pad_left_display(&s, FILE_EVENTS_WIDTH)
+    }
 }
 
-/// ファイルログ用 content カラムを生成する。
-fn file_content(entry: &LogEntry) -> String {
+/// アクションログのステップ番号・ラベル・本文を取り出す。Action系以外は None。
+fn action_step_parts(entry: &LogEntry) -> Option<(usize, String, String)> {
     match entry {
-        LogEntry::Match { path, .. } => path.clone(),
-        LogEntry::Action { detail, .. } => detail.replace('\n', r"\n"),
-        LogEntry::ActionOk { msg, .. } => msg.clone(),
-        LogEntry::Info(msg) => msg.clone(),
-        LogEntry::Warn(msg) => msg.clone(),
-        LogEntry::Error(msg) => msg.clone(),
-        LogEntry::Shutdown => unreachable!(),
+        LogEntry::Action { index, action_type, detail, .. } => {
+            Some((*index, action_type_short(action_type).to_string(), detail.replace('\n', r"\n")))
+        }
+        LogEntry::ActionOk { index, msg, .. } => Some((*index, "OK".to_string(), msg.clone())),
+        LogEntry::ActionErr { index, msg, .. } => Some((*index, "ERR".to_string(), msg.clone())),
+        LogEntry::ActionWarn { index, msg, .. } => Some((*index, "WARN".to_string(), msg.clone())),
+        LogEntry::ActionNote { index, msg, .. } => Some((*index, "--".to_string(), msg.clone())),
+        _ => None,
     }
+}
+
+/// アクションログのステップカラム文字列を生成する。
+/// `index == 0` は番号なし（ルール階層のチェーン全体エラー等）で描画する。
+fn render_step_col(index: usize, label: &str) -> String {
+    let s = if index == 0 {
+        label.to_string()
+    } else {
+        format!("{index}. {label}")
+    };
+    pad_left_display(&s, ACTION_STEP_WIDTH)
+}
+
+/// アクションログのブロック開始セパレータ行を生成する。
+fn render_block_start(
+    seq: usize,
+    ts: &str,
+    path: &str,
+    events: &HashSet<crate::config::Event>,
+    action_count: usize,
+) -> String {
+    format!(
+        "═══ #{seq}  {ts}  {path}  ({})  actions={action_count} ═══\n",
+        format_events(events)
+    )
+}
+
+/// 検知ログの1行を生成する。
+fn render_detect_line(ts: &str, events: &HashSet<crate::config::Event>, path: &str) -> String {
+    format!(
+        "{} │ {} │ {}\n",
+        ts,
+        pad_left_display(&format_events(events), DETECT_EVENTS_WIDTH),
+        path
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -278,15 +378,17 @@ async fn writer_task(
     mut rx: mpsc::UnboundedReceiver<LogEntry>,
     log_dir: String,
     log_file_name: String,
-    terminal_level: LogLevel,
-    file_level: LogLevel,
     log_rotation: LogRotation,
-    log_to_console: bool,
-    log_to_file: bool,
+    kind: LogKind,
+    level: LogLevel,
+    console: bool,
+    enabled: bool,
 ) {
     let mut current_date = Local::now().format("%Y%m%d").to_string();
     let log_path = build_log_path(&log_dir, &log_file_name);
-    let mut file = if log_to_file { open_log_file(&log_path).await } else { None };
+    let mut file = if enabled { open_log_file(&log_path).await } else { None };
+    // アクションログのブロック連番（日次ローテで #1 にリセット）。
+    let mut block_seq: usize = 0;
 
     while let Some(entry) = rx.recv().await {
         if matches!(entry, LogEntry::Shutdown) {
@@ -295,43 +397,66 @@ async fn writer_task(
 
         let now = Local::now();
         let today = now.format("%Y%m%d").to_string();
-        if log_to_file && matches!(log_rotation, LogRotation::Daily) && today != current_date {
+        if enabled && matches!(log_rotation, LogRotation::Daily) && today != current_date {
             if let Some(mut f) = file.take() {
                 let _ = f.flush().await;
             }
             current_date = today;
+            block_seq = 0;
             let new_path = build_log_path(&log_dir, &log_file_name);
             file = open_log_file(&new_path).await;
         }
 
         let ts = now.format("%Y-%m-%d %H:%M:%S").to_string();
 
-        // ─── ファイルログ（4カラム固定幅フォーマット）───────────────────────
-        if log_to_file {
-            let file_line = match &entry {
-                LogEntry::Match { .. } | LogEntry::Action { .. } | LogEntry::ActionOk { .. }
-                | LogEntry::Info(_) | LogEntry::Warn(_) | LogEntry::Error(_) => {
-                    if !level_enabled_for_entry(&file_level, &entry) {
-                        String::new()
-                    } else {
-                        let lv = file_level_col(&entry);
-                        let ev = file_events_col(&entry);
-                        let ct = file_content(&entry);
-                        format!("{} │ {} │ {} │ {}\n", ts, lv, ev, ct)
+        // ─── ファイルログ（kind 別フォーマット）─────────────────────────────
+        if enabled {
+            match kind {
+                LogKind::System => {
+                    if let Some(lbl) = sys_level_label(&entry) {
+                        if level_enabled_for_entry(&level, &entry) {
+                            let line = format!(
+                                "{} │ {} │ {}\n",
+                                ts,
+                                pad_left_display(lbl, SYS_LEVEL_WIDTH),
+                                sys_content(&entry)
+                            );
+                            write_file(&mut file, &line).await;
+                        }
                     }
                 }
-                LogEntry::Shutdown => unreachable!(),
-            };
-            if !file_line.is_empty() {
-                write_file(&mut file, &file_line).await;
+                LogKind::Detect => {
+                    if let LogEntry::Match { events, path, .. } = &entry {
+                        let line = render_detect_line(&ts, events, path);
+                        write_file(&mut file, &line).await;
+                    }
+                }
+                LogKind::Action => match &entry {
+                    LogEntry::ActionBlockStart { path, events, action_count } => {
+                        block_seq += 1;
+                        let line = render_block_start(block_seq, &ts, path, events, *action_count);
+                        write_file(&mut file, &line).await;
+                    }
+                    _ => {
+                        if let Some((idx, label, content)) = action_step_parts(&entry) {
+                            let line = format!(
+                                "{} │ {} │ {}\n",
+                                ts,
+                                render_step_col(idx, &label),
+                                content
+                            );
+                            write_file(&mut file, &line).await;
+                        }
+                    }
+                },
             }
         }
 
-        // ─── ターミナル出力（カラー付き従来フォーマット）─────────────────────
-        if log_to_console {
+        // ─── ターミナル出力（System ロガーのみ・カラー付き従来フォーマット）───
+        if console {
             match &entry {
                 LogEntry::Match { rule_name, path, events } => {
-                    if !level_enabled(&terminal_level, &LogLevel::Info) { continue; }
+                    if !level_enabled(&level, &LogLevel::Info) { continue; }
                     let event_str = format_events(events);
                     let term_line = format!(
                         "{}\n{} {}",
@@ -343,7 +468,7 @@ async fn writer_task(
                 }
 
                 LogEntry::Action { index, total, action_type, detail } => {
-                    if !level_enabled(&terminal_level, &LogLevel::Info) { continue; }
+                    if !level_enabled(&level, &LogLevel::Info) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [ACTION]").blue().bold(),
@@ -353,7 +478,7 @@ async fn writer_task(
                 }
 
                 LogEntry::ActionOk { msg, .. } => {
-                    if !level_enabled(&terminal_level, &LogLevel::Info) { continue; }
+                    if !level_enabled(&level, &LogLevel::Info) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [OK]    ").green().bold(),
@@ -362,8 +487,38 @@ async fn writer_task(
                     println!("{}", term_line);
                 }
 
+                LogEntry::ActionNote { msg, .. } => {
+                    if !level_enabled(&level, &LogLevel::Info) { continue; }
+                    let term_line = format!(
+                        "{} {}",
+                        format!("[{ts}] [INFO]").cyan(),
+                        msg
+                    );
+                    println!("{}", term_line);
+                }
+
+                LogEntry::ActionWarn { msg, .. } => {
+                    if !level_enabled(&level, &LogLevel::Warn) { continue; }
+                    let term_line = format!(
+                        "{} {}",
+                        format!("[{ts}] [WARN]").yellow().bold(),
+                        msg
+                    );
+                    println!("{}", term_line);
+                }
+
+                LogEntry::ActionErr { msg, .. } => {
+                    if !level_enabled(&level, &LogLevel::Error) { continue; }
+                    let term_line = format!(
+                        "{} {}",
+                        format!("[{ts}] [ERROR]").red().bold(),
+                        msg
+                    );
+                    eprintln!("{}", term_line);
+                }
+
                 LogEntry::Info(msg) => {
-                    if !level_enabled(&terminal_level, &LogLevel::Info) { continue; }
+                    if !level_enabled(&level, &LogLevel::Info) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [INFO]").cyan(),
@@ -373,7 +528,7 @@ async fn writer_task(
                 }
 
                 LogEntry::Warn(msg) => {
-                    if !level_enabled(&terminal_level, &LogLevel::Warn) { continue; }
+                    if !level_enabled(&level, &LogLevel::Warn) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [WARN]").yellow().bold(),
@@ -383,7 +538,7 @@ async fn writer_task(
                 }
 
                 LogEntry::Error(msg) => {
-                    if !level_enabled(&terminal_level, &LogLevel::Error) { continue; }
+                    if !level_enabled(&level, &LogLevel::Error) { continue; }
                     let term_line = format!(
                         "{} {}",
                         format!("[{ts}] [ERROR]").red().bold(),
@@ -392,6 +547,8 @@ async fn writer_task(
                     eprintln!("{}", term_line);
                 }
 
+                // ブロック開始セパレータはファイル専用（コンソールには出さない）
+                LogEntry::ActionBlockStart { .. } => {}
                 LogEntry::Shutdown => unreachable!(),
             }
         }
@@ -451,46 +608,117 @@ fn format_events(events: &HashSet<crate::config::Event>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Event;
 
-    /// 罫線文字 ('└') は East Asian Ambiguous で、CJK モードでは 2 列幅。
-    /// "└1 log" は 2+1+1+1+1+1 = 7 列、ピッタリ収まる。
-    #[test]
-    fn test_pad_left_display_with_eaw_chars() {
-        let s = pad_left_display("└1 log", 7);
-        assert_eq!(UnicodeWidthStr::width_cjk(s.as_str()), 7);
-        assert_eq!(s, "└1 log"); // 既に 7 列なので追加スペースなし
+    fn events(list: &[Event]) -> HashSet<Event> {
+        list.iter().cloned().collect()
     }
 
-    /// ASCII のみの文字列は char 数と CJK 列幅が一致する
     #[test]
     fn test_pad_left_display_ascii() {
-        let s = pad_left_display("MATCH", 7);
-        assert_eq!(s, "MATCH  ");
-        assert_eq!(UnicodeWidthStr::width_cjk(s.as_str()), 7);
+        let s = pad_left_display("INFO", SYS_LEVEL_WIDTH);
+        assert_eq!(s, "INFO ");
+        assert_eq!(UnicodeWidthStr::width_cjk(s.as_str()), SYS_LEVEL_WIDTH);
     }
 
-    /// '│' は CJK で 2 列幅。"│   OK" は 2+3+2 = 7 列。
     #[test]
-    fn test_pad_left_display_middle_action_ok() {
-        let s = pad_left_display("│   OK", 7);
-        assert_eq!(UnicodeWidthStr::width_cjk(s.as_str()), 7);
-    }
-
-    /// 列幅オーバーは切り詰めず返す (元の動作維持)
-    #[test]
-    fn test_pad_left_display_overflow() {
+    fn test_pad_left_display_overflow_not_truncated() {
         let s = pad_left_display("VERYLONGTEXT", 5);
         assert_eq!(s, "VERYLONGTEXT");
     }
 
-    /// 罫線なしのレベル文字列が CJK 列幅 7 列で揃う
+    /// ステップカラムはペア番号付き（`1. copy` ↔ `1. OK`）で揃う。
     #[test]
-    fn test_pad_left_display_info_aligns_with_match() {
-        let info = pad_left_display("INFO", FILE_LEVEL_WIDTH);
-        let match_ = pad_left_display("MATCH", FILE_LEVEL_WIDTH);
-        let action_ok = pad_left_display("│   OK", FILE_LEVEL_WIDTH);
-        assert_eq!(UnicodeWidthStr::width_cjk(info.as_str()), FILE_LEVEL_WIDTH);
-        assert_eq!(UnicodeWidthStr::width_cjk(match_.as_str()), FILE_LEVEL_WIDTH);
-        assert_eq!(UnicodeWidthStr::width_cjk(action_ok.as_str()), FILE_LEVEL_WIDTH);
+    fn test_render_step_col_numbered_pair() {
+        let start = render_step_col(1, "copy");
+        let ok = render_step_col(1, "OK");
+        assert!(start.starts_with("1. copy"));
+        assert!(ok.starts_with("1. OK"));
+        assert_eq!(UnicodeWidthStr::width_cjk(start.as_str()), ACTION_STEP_WIDTH);
+        assert_eq!(UnicodeWidthStr::width_cjk(ok.as_str()), ACTION_STEP_WIDTH);
+    }
+
+    /// index 0 は番号なしで描画する（チェーン全体エラー等）。
+    #[test]
+    fn test_render_step_col_index_zero_no_number() {
+        let s = render_step_col(0, "ERR");
+        assert!(s.starts_with("ERR"));
+        assert!(!s.contains('.'));
+    }
+
+    /// ブロック開始セパレータに連番・パス・イベント・アクション数が入る。
+    #[test]
+    fn test_render_block_start_contains_fields() {
+        let line = render_block_start(
+            1,
+            "2026-06-07 10:05:30",
+            "C:/watch/csv/data.csv",
+            &events(&[Event::Create]),
+            2,
+        );
+        assert!(line.starts_with("═══ #1"));
+        assert!(line.contains("C:/watch/csv/data.csv"));
+        assert!(line.contains("(Create)"));
+        assert!(line.contains("actions=2"));
+    }
+
+    /// 検知ログは 3 カラム（ts │ events │ path）で出力する。
+    #[test]
+    fn test_render_detect_line_three_columns() {
+        let line = render_detect_line(
+            "2026-06-07 10:05:30",
+            &events(&[Event::Create, Event::Modify]),
+            "C:/watch/a.csv",
+        );
+        assert_eq!(line.matches('│').count(), 2);
+        assert!(line.contains("Create,Modify"));
+        assert!(line.contains("C:/watch/a.csv"));
+    }
+
+    /// システムログには Info/Warn/Error のみラベルが付き、検知/アクション系は None。
+    #[test]
+    fn test_sys_level_label_skips_action_entries() {
+        assert_eq!(sys_level_label(&LogEntry::Info("x".into())), Some("INFO"));
+        assert_eq!(sys_level_label(&LogEntry::Warn("x".into())), Some("WARN"));
+        assert_eq!(sys_level_label(&LogEntry::Error("x".into())), Some("ERROR"));
+        assert_eq!(
+            sys_level_label(&LogEntry::Match {
+                rule_name: "r".into(),
+                path: "p".into(),
+                events: events(&[Event::Create]),
+            }),
+            None
+        );
+        assert_eq!(
+            sys_level_label(&LogEntry::ActionOk { index: 1, total: 1, msg: "ok".into() }),
+            None
+        );
+        assert_eq!(
+            sys_level_label(&LogEntry::ActionErr { index: 1, total: 1, msg: "e".into() }),
+            None
+        );
+    }
+
+    /// action_step_parts が各 Action 系エントリを正しく分解する。
+    #[test]
+    fn test_action_step_parts_labels() {
+        let ok = LogEntry::ActionOk { index: 2, total: 3, msg: "done".into() };
+        assert_eq!(action_step_parts(&ok), Some((2, "OK".to_string(), "done".to_string())));
+        let err = LogEntry::ActionErr { index: 1, total: 2, msg: "boom".into() };
+        assert_eq!(action_step_parts(&err), Some((1, "ERR".to_string(), "boom".to_string())));
+        let cmd = LogEntry::Action {
+            index: 1,
+            total: 1,
+            action_type: "command".into(),
+            detail: "shell=cmd".into(),
+        };
+        assert_eq!(action_step_parts(&cmd), Some((1, "cmd".to_string(), "shell=cmd".to_string())));
+        // Match は Action 系ではない
+        let m = LogEntry::Match {
+            rule_name: "r".into(),
+            path: "p".into(),
+            events: events(&[Event::Create]),
+        };
+        assert_eq!(action_step_parts(&m), None);
     }
 }

--- a/cat-watcher/src/logger.rs
+++ b/cat-watcher/src/logger.rs
@@ -276,9 +276,22 @@ fn build_log_path(log_dir: &str, log_file_name: &str) -> PathBuf {
     PathBuf::from(log_dir).join(file_name)
 }
 
-async fn open_log_file(path: &PathBuf) -> Option<tokio::fs::File> {
+/// ログファイルを **書き込み時だけ** open → 追記 → close する（Issue #46）。
+/// バッチ単位でまとめて呼ぶことで、ハンドルを握りっぱなしにせず、かつ
+/// open/close のシステムコール回数を抑える。`content` が空なら何もしない。
+async fn append_to_file(path: &PathBuf, content: &str) {
+    if content.is_empty() {
+        return;
+    }
     match OpenOptions::new().create(true).append(true).open(path).await {
-        Ok(f) => Some(f),
+        Ok(mut f) => {
+            if let Err(e) = f.write_all(content.as_bytes()).await {
+                let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
+                eprintln!("{}", format!("[{ts}] [ERROR] ログ書き込み失敗: {e}").red().bold());
+            }
+            // f はここで drop され、ファイルが閉じられる（明示 flush で確実に書き出す）
+            let _ = f.flush().await;
+        }
         Err(e) => {
             let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
             eprintln!(
@@ -287,7 +300,6 @@ async fn open_log_file(path: &PathBuf) -> Option<tokio::fs::File> {
                     .red()
                     .bold()
             );
-            None
         }
     }
 }
@@ -385,186 +397,161 @@ async fn writer_task(
     enabled: bool,
 ) {
     let mut current_date = Local::now().format("%Y%m%d").to_string();
-    let log_path = build_log_path(&log_dir, &log_file_name);
-    let mut file = if enabled { open_log_file(&log_path).await } else { None };
     // アクションログのブロック連番（日次ローテで #1 にリセット）。
     let mut block_seq: usize = 0;
 
-    while let Some(entry) = rx.recv().await {
-        if matches!(entry, LogEntry::Shutdown) {
-            break;
+    while let Some(first) = rx.recv().await {
+        // バッチ収集（Issue #46）: まず 1 件を待ち、キューにたまっている分を
+        // try_recv で一気にすくい取る。こうしてバッチ単位で 1 回だけ
+        // open → write → close することで、ハンドルを握りっぱなしにせず、
+        // かつ open/close のシステムコール回数も抑える。
+        let mut batch = vec![first];
+        loop {
+            match rx.try_recv() {
+                Ok(e) => batch.push(e),
+                Err(_) => break,
+            }
         }
 
         let now = Local::now();
         let today = now.format("%Y%m%d").to_string();
-        if enabled && matches!(log_rotation, LogRotation::Daily) && today != current_date {
-            if let Some(mut f) = file.take() {
-                let _ = f.flush().await;
-            }
+        // 日次ローテ: 日付が変わったら block_seq をリセットする。出力先パスは
+        // build_log_path が {Date} を差し替えるため自動的に当日のファイルへ向く。
+        if matches!(log_rotation, LogRotation::Daily) && today != current_date {
             current_date = today;
             block_seq = 0;
-            let new_path = build_log_path(&log_dir, &log_file_name);
-            file = open_log_file(&new_path).await;
         }
-
         let ts = now.format("%Y-%m-%d %H:%M:%S").to_string();
 
-        // ─── ファイルログ（kind 別フォーマット）─────────────────────────────
+        // このバッチで書くファイル行をためるバッファ（最後に 1 回だけ書き出す）。
+        let mut file_buf = String::new();
+        let mut shutdown = false;
+
+        for entry in &batch {
+            if matches!(entry, LogEntry::Shutdown) {
+                shutdown = true;
+                break;
+            }
+            if enabled {
+                if let Some(line) = file_line(entry, kind, &ts, &level, &mut block_seq) {
+                    file_buf.push_str(&line);
+                }
+            }
+            // ターミナル出力は従来どおり 1 件ずつ即時に行う（System ロガーのみ）。
+            if console {
+                console_print(entry, &ts, &level);
+            }
+        }
+
+        // バッチをまとめて 1 回の open → write → close で書き出す。
         if enabled {
-            match kind {
-                LogKind::System => {
-                    if let Some(lbl) = sys_level_label(&entry) {
-                        if level_enabled_for_entry(&level, &entry) {
-                            let line = format!(
-                                "{} │ {} │ {}\n",
-                                ts,
-                                pad_left_display(lbl, SYS_LEVEL_WIDTH),
-                                sys_content(&entry)
-                            );
-                            write_file(&mut file, &line).await;
-                        }
-                    }
-                }
-                LogKind::Detect => {
-                    if let LogEntry::Match { events, path, .. } = &entry {
-                        let line = render_detect_line(&ts, events, path);
-                        write_file(&mut file, &line).await;
-                    }
-                }
-                LogKind::Action => match &entry {
-                    LogEntry::ActionBlockStart { path, events, action_count } => {
-                        block_seq += 1;
-                        let line = render_block_start(block_seq, &ts, path, events, *action_count);
-                        write_file(&mut file, &line).await;
-                    }
-                    _ => {
-                        if let Some((idx, label, content)) = action_step_parts(&entry) {
-                            let line = format!(
-                                "{} │ {} │ {}\n",
-                                ts,
-                                render_step_col(idx, &label),
-                                content
-                            );
-                            write_file(&mut file, &line).await;
-                        }
-                    }
-                },
-            }
+            append_to_file(&build_log_path(&log_dir, &log_file_name), &file_buf).await;
         }
-
-        // ─── ターミナル出力（System ロガーのみ・カラー付き従来フォーマット）───
-        if console {
-            match &entry {
-                LogEntry::Match { rule_name, path, events } => {
-                    if !level_enabled(&level, &LogLevel::Info) { continue; }
-                    let event_str = format_events(events);
-                    let term_line = format!(
-                        "{}\n{} {}",
-                        SEPARATOR.bright_green().dimmed(),
-                        format!("[{ts}] [MATCH]").bright_green().bold(),
-                        format!("  ルール={rule_name} | パス={path} | {event_str}")
-                    );
-                    println!("{}", term_line);
-                }
-
-                LogEntry::Action { index, total, action_type, detail } => {
-                    if !level_enabled(&level, &LogLevel::Info) { continue; }
-                    let term_line = format!(
-                        "{} {}",
-                        format!("[{ts}] [ACTION]").blue().bold(),
-                        format!("  ({index}/{total}) {action_type}  {detail}")
-                    );
-                    println!("{}", term_line);
-                }
-
-                LogEntry::ActionOk { msg, .. } => {
-                    if !level_enabled(&level, &LogLevel::Info) { continue; }
-                    let term_line = format!(
-                        "{} {}",
-                        format!("[{ts}] [OK]    ").green().bold(),
-                        msg
-                    );
-                    println!("{}", term_line);
-                }
-
-                LogEntry::ActionNote { msg, .. } => {
-                    if !level_enabled(&level, &LogLevel::Info) { continue; }
-                    let term_line = format!(
-                        "{} {}",
-                        format!("[{ts}] [INFO]").cyan(),
-                        msg
-                    );
-                    println!("{}", term_line);
-                }
-
-                LogEntry::ActionWarn { msg, .. } => {
-                    if !level_enabled(&level, &LogLevel::Warn) { continue; }
-                    let term_line = format!(
-                        "{} {}",
-                        format!("[{ts}] [WARN]").yellow().bold(),
-                        msg
-                    );
-                    println!("{}", term_line);
-                }
-
-                LogEntry::ActionErr { msg, .. } => {
-                    if !level_enabled(&level, &LogLevel::Error) { continue; }
-                    let term_line = format!(
-                        "{} {}",
-                        format!("[{ts}] [ERROR]").red().bold(),
-                        msg
-                    );
-                    eprintln!("{}", term_line);
-                }
-
-                LogEntry::Info(msg) => {
-                    if !level_enabled(&level, &LogLevel::Info) { continue; }
-                    let term_line = format!(
-                        "{} {}",
-                        format!("[{ts}] [INFO]").cyan(),
-                        msg
-                    );
-                    println!("{}", term_line);
-                }
-
-                LogEntry::Warn(msg) => {
-                    if !level_enabled(&level, &LogLevel::Warn) { continue; }
-                    let term_line = format!(
-                        "{} {}",
-                        format!("[{ts}] [WARN]").yellow().bold(),
-                        msg
-                    );
-                    println!("{}", term_line);
-                }
-
-                LogEntry::Error(msg) => {
-                    if !level_enabled(&level, &LogLevel::Error) { continue; }
-                    let term_line = format!(
-                        "{} {}",
-                        format!("[{ts}] [ERROR]").red().bold(),
-                        msg
-                    );
-                    eprintln!("{}", term_line);
-                }
-
-                // ブロック開始セパレータはファイル専用（コンソールには出さない）
-                LogEntry::ActionBlockStart { .. } => {}
-                LogEntry::Shutdown => unreachable!(),
-            }
+        if shutdown {
+            break;
         }
-    }
-
-    if let Some(mut f) = file {
-        let _ = f.flush().await;
     }
 }
 
-async fn write_file(file: &mut Option<tokio::fs::File>, line: &str) {
-    if let Some(f) = file {
-        if let Err(e) = f.write_all(line.as_bytes()).await {
-            let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
-            eprintln!("{}", format!("[{ts}] [ERROR] ログ書き込み失敗: {e}").red().bold());
+/// 1 エントリのファイル出力行を生成する（kind 別フォーマット）。
+/// 書き込み対象外なら None。`block_seq` はアクションブロック開始で +1 する。
+fn file_line(
+    entry: &LogEntry,
+    kind: LogKind,
+    ts: &str,
+    level: &LogLevel,
+    block_seq: &mut usize,
+) -> Option<String> {
+    match kind {
+        LogKind::System => {
+            let lbl = sys_level_label(entry)?;
+            if !level_enabled_for_entry(level, entry) {
+                return None;
+            }
+            Some(format!(
+                "{} │ {} │ {}\n",
+                ts,
+                pad_left_display(lbl, SYS_LEVEL_WIDTH),
+                sys_content(entry)
+            ))
         }
+        LogKind::Detect => match entry {
+            LogEntry::Match { events, path, .. } => Some(render_detect_line(ts, events, path)),
+            _ => None,
+        },
+        LogKind::Action => match entry {
+            LogEntry::ActionBlockStart { path, events, action_count } => {
+                *block_seq += 1;
+                Some(render_block_start(*block_seq, ts, path, events, *action_count))
+            }
+            _ => action_step_parts(entry).map(|(idx, label, content)| {
+                format!("{} │ {} │ {}\n", ts, render_step_col(idx, &label), content)
+            }),
+        },
+    }
+}
+
+/// 1 エントリをターミナルへカラー付きで出力する（従来フォーマットを維持）。
+fn console_print(entry: &LogEntry, ts: &str, level: &LogLevel) {
+    match entry {
+        LogEntry::Match { rule_name, path, events } => {
+            if !level_enabled(level, &LogLevel::Info) { return; }
+            let event_str = format_events(events);
+            println!(
+                "{}\n{} {}",
+                SEPARATOR.bright_green().dimmed(),
+                format!("[{ts}] [MATCH]").bright_green().bold(),
+                format!("  ルール={rule_name} | パス={path} | {event_str}")
+            );
+        }
+
+        LogEntry::Action { index, total, action_type, detail } => {
+            if !level_enabled(level, &LogLevel::Info) { return; }
+            println!(
+                "{} {}",
+                format!("[{ts}] [ACTION]").blue().bold(),
+                format!("  ({index}/{total}) {action_type}  {detail}")
+            );
+        }
+
+        LogEntry::ActionOk { msg, .. } => {
+            if !level_enabled(level, &LogLevel::Info) { return; }
+            println!("{} {}", format!("[{ts}] [OK]    ").green().bold(), msg);
+        }
+
+        LogEntry::ActionNote { msg, .. } => {
+            if !level_enabled(level, &LogLevel::Info) { return; }
+            println!("{} {}", format!("[{ts}] [INFO]").cyan(), msg);
+        }
+
+        LogEntry::ActionWarn { msg, .. } => {
+            if !level_enabled(level, &LogLevel::Warn) { return; }
+            println!("{} {}", format!("[{ts}] [WARN]").yellow().bold(), msg);
+        }
+
+        LogEntry::ActionErr { msg, .. } => {
+            if !level_enabled(level, &LogLevel::Error) { return; }
+            eprintln!("{} {}", format!("[{ts}] [ERROR]").red().bold(), msg);
+        }
+
+        LogEntry::Info(msg) => {
+            if !level_enabled(level, &LogLevel::Info) { return; }
+            println!("{} {}", format!("[{ts}] [INFO]").cyan(), msg);
+        }
+
+        LogEntry::Warn(msg) => {
+            if !level_enabled(level, &LogLevel::Warn) { return; }
+            println!("{} {}", format!("[{ts}] [WARN]").yellow().bold(), msg);
+        }
+
+        LogEntry::Error(msg) => {
+            if !level_enabled(level, &LogLevel::Error) { return; }
+            eprintln!("{} {}", format!("[{ts}] [ERROR]").red().bold(), msg);
+        }
+
+        // ブロック開始セパレータはファイル専用（コンソールには出さない）
+        LogEntry::ActionBlockStart { .. } => {}
+        LogEntry::Shutdown => {}
     }
 }
 

--- a/cat-watcher/src/main.rs
+++ b/cat-watcher/src/main.rs
@@ -171,7 +171,7 @@ async fn run(cli: &Args) -> Result<(), AppError> {
         return Ok(());
     }
 
-    let (log, log_handle) = logger::Logger::new(&global_config.global)?;
+    let (log, log_handle) = logger::Logger::new_system(&global_config.system_log, true)?;
     let log = Arc::new(log);
 
     log.info(format!(
@@ -180,11 +180,15 @@ async fn run(cli: &Args) -> Result<(), AppError> {
         rules_path.display()
     ));
 
-    watcher::start_watching(&rules_conf.rules, &global_config.global, Arc::clone(&log)).await?;
+    let result = watcher::start_watching(&rules_conf.rules, &global_config.retry, Arc::clone(&log)).await;
+    if let Err(e) = &result {
+        // 監視処理の異常終了はシステム階層のエラーとしてシステムログに残す。
+        log.error(format!("監視処理が異常終了しました: {e}"));
+    }
 
     log.shutdown();
     let _ = log_handle.await;
-    Ok(())
+    result
 }
 
 fn exit_on_err(result: Result<(), AppError>) {

--- a/cat-watcher/src/router.rs
+++ b/cat-watcher/src/router.rs
@@ -9,7 +9,7 @@ use notify::EventKind;
 use notify::event::{CreateKind, ModifyKind, RemoveKind};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
-use crate::{config::{ActionConfig, Event, Global, Rule, WatchTarget}, error::AppError};
+use crate::{config::{ActionConfig, Event, RetryConfig, Rule, WatchTarget}, error::AppError};
 use crate::logger::Logger;
 
 /// イベントが指すエントリの種別。
@@ -57,10 +57,11 @@ pub struct CompiledRule{
 	pub dir_regex: Option<Regex>,
 	pub regexes: Option<Regex>,
 	pub actions: Vec<ActionConfig>,
-	pub rule_logger: Option<Arc<Logger>>,
+	pub detect_logger: Option<Arc<Logger>>,
+	pub action_logger: Option<Arc<Logger>>,
 }
 
-pub fn compile_rules(rules: &[Rule], global: &Global) -> Result<(Vec<CompiledRule>, Vec<tokio::task::JoinHandle<()>>), AppError> {
+pub fn compile_rules(rules: &[Rule]) -> Result<(Vec<CompiledRule>, Vec<tokio::task::JoinHandle<()>>), AppError> {
 	let mut compiled_rules = Vec::new();
 	let mut log_handles = Vec::new();
 	for rule in rules{
@@ -130,25 +131,34 @@ pub fn compile_rules(rules: &[Rule], global: &Global) -> Result<(Vec<CompiledRul
 			None
 		};
 		
-		let rule_logger = if let Some(rule_log) = &rule.log {
-			if rule_log.enabled {
-				let log_dir = rule_log.log_dir.clone()
-					.unwrap_or_else(|| global.log_dir.clone());
-				let log_file_name = rule_log.log_file_name.clone()
-					.unwrap_or_else(|| global.log_file_name.clone());
-				let log_rotation = rule_log.log_rotation.clone()
-					.unwrap_or_else(|| global.log_rotation.clone());
-				let file_level = global.file_log_level.clone()
-					.unwrap_or_else(|| global.log_level.clone());
-				let (logger, handle) = Logger::for_rule(log_dir, log_file_name, log_rotation, file_level)?;
-				log_handles.push(handle);
-				Some(Arc::new(logger))
-			} else {
-				None
+		// 検知ログ・アクションログをそれぞれ個別に生成する（global からの
+		// フォールバックは廃止。各ターゲットが dir/file_name/rotation を必須で持つ）。
+		let mut detect_logger = None;
+		let mut action_logger = None;
+		if let Some(rule_log) = &rule.log {
+			if let Some(detect) = &rule_log.detect {
+				if detect.enabled {
+					let (logger, handle) = Logger::for_detect(
+						detect.dir.clone(),
+						detect.file_name.clone(),
+						detect.rotation.clone(),
+					)?;
+					log_handles.push(handle);
+					detect_logger = Some(Arc::new(logger));
+				}
 			}
-		} else {
-			None
-		};
+			if let Some(action) = &rule_log.action {
+				if action.enabled {
+					let (logger, handle) = Logger::for_action(
+						action.dir.clone(),
+						action.file_name.clone(),
+						action.rotation.clone(),
+					)?;
+					log_handles.push(handle);
+					action_logger = Some(Arc::new(logger));
+				}
+			}
+		}
 
 		compiled_rules.push(CompiledRule {
 			name: rule.name.clone(),
@@ -167,7 +177,8 @@ pub fn compile_rules(rules: &[Rule], global: &Global) -> Result<(Vec<CompiledRul
 			dir_regex,
 			regexes,
 			actions: rule.actions.clone(),
-			rule_logger,
+			detect_logger,
+			action_logger,
 		});
 	}
 	Ok((compiled_rules, log_handles))
@@ -323,7 +334,7 @@ fn to_config_event(kind: &EventKind) -> Option<Event> {
 pub async fn run_router(
     mut rx: mpsc::Receiver<notify::Result<notify::Event>>,
     compiled_rules: &[CompiledRule],
-    global: &Global,
+    retry: &RetryConfig,
     log: Arc<Logger>,
 ) -> Result<(), AppError> {
     // デバウンス用マップ: パス → (イベント集合, 最後の受信時刻, EntryKind)
@@ -369,39 +380,40 @@ pub async fn run_router(
                             continue;
                         }
 
+                        // 検知: ターミナル（system）＋検知ログ（ルール別ファイル）へ
                         log.log_match(
                             &rule.name,
                             path.display().to_string(),
                             detected_events.clone(),
                         );
-                        if let Some(rl) = &rule.rule_logger {
-                            rl.log_match(
+                        if let Some(dl) = &rule.detect_logger {
+                            dl.log_match(
                                 &rule.name,
                                 path.display().to_string(),
                                 detected_events.clone(),
                             );
                         }
 
+                        // アクションログのブロック開始セパレータ
+                        if let Some(al) = &rule.action_logger {
+                            al.log_block_start(
+                                path.display().to_string(),
+                                detected_events.clone(),
+                                rule.actions.len(),
+                            );
+                        }
+
                         let watch_path = PathBuf::from(&rule.watch_path);
-                        if let Err(e) = crate::actions::execute_chain(
+                        // アクション失敗時のログ出力は execute_chain 内（ActionSink）で
+                        // 完結する（ターミナル＋アクションログ）。ここでは再ログしない。
+                        let _ = crate::actions::execute_chain(
                             &rule.actions,
                             &path,
                             &watch_path,
-                            global,
+                            retry,
                             Arc::clone(&log),
-                            rule.rule_logger.clone(),
-                        ).await {
-                            log.error(format!(
-                                "アクションチェーン実行エラー: ルール={}, パス={}, エラー={}",
-                                rule.name, path.display(), e
-                            ));
-                            if let Some(rl) = &rule.rule_logger {
-                                rl.error(format!(
-                                    "アクションチェーン実行エラー: パス={}, エラー={}",
-                                    path.display(), e
-                                ));
-                            }
-                        }
+                            rule.action_logger.clone(),
+                        ).await;
                     }
                 }
             }
@@ -447,7 +459,8 @@ mod tests {
             dir_regex: None,
             regexes: None,
             actions: vec![],
-            rule_logger: None,
+            detect_logger: None,
+            action_logger: None,
         }
     }
 

--- a/cat-watcher/src/service.rs
+++ b/cat-watcher/src/service.rs
@@ -122,17 +122,14 @@ fn run_watcher(
         config::validate_global_config(&global_config)?;
         config::validate_rules_config(&rules_conf)?;
 
-        // サービスモードではコンソール出力を無効化する
-        let mut service_global = global_config.global.clone();
-        service_global.log_to_console = false;
-
-        let (log, log_handle) = Logger::new(&service_global)?;
+        // サービスモードではコンソール出力を無効化する（allow_console=false）
+        let (log, log_handle) = Logger::new_system(&global_config.system_log, false)?;
         let log = Arc::new(log);
 
         log.info("Windowsサービスとして起動しました".to_string());
 
         let result = tokio::select! {
-            result = watcher::start_watching(&rules_conf.rules, &service_global, Arc::clone(&log)) => result,
+            result = watcher::start_watching(&rules_conf.rules, &global_config.retry, Arc::clone(&log)) => result,
             _ = stop_rx => {
                 let _ = status_handle.set_service_status(ServiceStatus {
                     service_type: ServiceType::OWN_PROCESS,

--- a/cat-watcher/src/templates.rs
+++ b/cat-watcher/src/templates.rs
@@ -1,14 +1,18 @@
-pub const GLOBAL_TOML: &str = r#"[global]
-log_level         = "info"    # trace / debug / info / warn / error
-log_dir           = "C:\logs"
-log_file_name     = "cat-watcher_{Date}.log"  # {Date} / {DateTime}
-log_rotation      = "daily"                   # daily / never
-retry_count       = 3
-retry_interval_ms = 1000
-# log_to_console       = true   # コンソールへのログ出力（デフォルト: true）
-# log_to_file          = true   # ファイルへのログ出力（デフォルト: true）
-# terminal_log_level   = "info" # コンソール専用ログレベル（省略時は log_level を使用）
-# file_log_level       = "info" # ファイル専用ログレベル（省略時は log_level を使用）
+pub const GLOBAL_TOML: &str = r#"# ─── リトライ設定（copy / move 失敗時の再試行）─────────────────────────
+[retry]
+count       = 3       # 再試行回数
+interval_ms = 1000    # 再試行間隔（ミリ秒）
+
+# ─── システムログ（プログラム全体の起動日誌・全体で1本）───────────────
+# 起動バナー / ルール一覧 / 監視開始 / 終了 と、システム階層のエラーを記録。
+# 検知・アクションの結果はルール別ログ（rules.toml の [rules.log]）に出ます。
+[system_log]
+enabled   = true
+dir       = "C:\logs"
+file_name = "system_{Date}.log"   # {Date} / {DateTime}
+rotation  = "daily"               # daily / never
+level     = "info"                # trace / debug / info / warn / error
+console   = true                  # コンソールへの出力 ON/OFF
 "#;
 
 pub const RULES_TOML: &str = r#"[[rules]]
@@ -24,6 +28,23 @@ patterns         = ["*"]           # glob（regex と排他）
 # regex          = ".*\\.csv$"     # 正規表現（patterns と排他）
 exclude_patterns = []
 events           = ["create"]      # create / modify / delete / rename
+
+# ─── ルール別ログ（検知ログ・アクションログ）────────────────────────────
+# detect: 検知イベントだけを記録（timestamp │ events │ 検知パス）
+# action: 検知ごとのアクション実行内容をブロック形式で記録
+# どちらも enabled で個別に ON/OFF できます。
+
+[rules.log.detect]
+enabled   = true
+dir       = "C:\logs"
+file_name = "detect_ルール名_{Date}.log"
+rotation  = "daily"
+
+[rules.log.action]
+enabled   = true
+dir       = "C:\logs"
+file_name = "action_ルール名_{Date}.log"
+rotation  = "daily"
 
 # ─── アクション例（使うものだけコメント解除してください） ────────────────
 

--- a/cat-watcher/src/templates.rs
+++ b/cat-watcher/src/templates.rs
@@ -8,7 +8,7 @@ interval_ms = 1000    # 再試行間隔（ミリ秒）
 # 検知・アクションの結果はルール別ログ（rules.toml の [rules.log]）に出ます。
 [system_log]
 enabled   = true
-dir       = "C:\logs"
+dir       = 'C:\logs'
 file_name = "system_{Date}.log"   # {Date} / {DateTime}
 rotation  = "daily"               # daily / never
 level     = "info"                # trace / debug / info / warn / error
@@ -20,7 +20,7 @@ enabled = true
 name    = "ルール名"
 
 [rules.watch]
-path             = "C:\監視フォルダ"
+path             = 'C:\監視フォルダ'
 recursive        = true
 target           = "file"          # file / directory / both
 include_hidden   = false
@@ -36,13 +36,13 @@ events           = ["create"]      # create / modify / delete / rename
 
 [rules.log.detect]
 enabled   = true
-dir       = "C:\logs"
+dir       = 'C:\logs'
 file_name = "detect_ルール名_{Date}.log"
 rotation  = "daily"
 
 [rules.log.action]
 enabled   = true
-dir       = "C:\logs"
+dir       = 'C:\logs'
 file_name = "action_ルール名_{Date}.log"
 rotation  = "daily"
 
@@ -54,14 +54,14 @@ message = "検知: {BaseName}"
 
 # [[rules.actions]]                # ─── copy ──────────────────────────────
 # type               = "copy"
-# destination        = "D:\backup\{Date}"
+# destination        = 'D:\backup\{Date}'
 # overwrite          = false
 # preserve_structure = false
 # verify_integrity   = true
 
 # [[rules.actions]]                # ─── move ──────────────────────────────
 # type               = "move"
-# destination        = "D:\archive\{Date}"
+# destination        = 'D:\archive\{Date}'
 # overwrite          = false
 # preserve_structure = false
 # verify_integrity   = false
@@ -74,7 +74,7 @@ message = "検知: {BaseName}"
 
 # [[rules.actions]]                # ─── execute ────────────────────────────
 # type        = "execute"
-# program     = "C:\tool\app.exe"
+# program     = 'C:\tool\app.exe'
 # args        = ["{FullName}"]
 # working_dir = ""
 "#;

--- a/cat-watcher/src/watcher.rs
+++ b/cat-watcher/src/watcher.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use notify::{recommended_watcher, Event, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
 
-use crate::config::{Global, Rule};
+use crate::config::{RetryConfig, Rule};
 use crate::error::AppError;
 use crate::logger::Logger;
 
@@ -25,7 +25,7 @@ fn strip_unc_prefix(path: &PathBuf) -> String {
 
 pub async fn start_watching(
     rules: &[Rule],
-    global: &Global,
+    retry: &RetryConfig,
     log: Arc<Logger>,
 ) -> Result<(), AppError> {
     let (tx, rx) = mpsc::channel::<notify::Result<Event>>(100);
@@ -37,10 +37,6 @@ pub async fn start_watching(
 
     let mut watch_map: HashMap<PathBuf, RecursiveMode> = HashMap::new();
     for rule in rules {
-        if !rule.enabled {
-            continue;
-        }
-
         let path = PathBuf::from(&rule.watch.path);
         let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
         let canonical_display = strip_unc_prefix(&canonical);
@@ -64,14 +60,21 @@ pub async fn start_watching(
             .join(", ");
 
         let recursive_str = if rule.watch.recursive { "あり" } else { "なし" };
+        let status = if rule.enabled { "有効" } else { "無効" };
 
         log.info(format!(
-            "監視ルール [{}]  パス={}  イベント={}  サブフォルダ={}",
+            "監視ルール [{}] ({})  パス={}  イベント={}  サブフォルダ={}",
             rule.name,
+            status,
             canonical_display,
             events_str,
             recursive_str,
         ));
+
+        // 無効ルールは一覧に記載するだけで、フィルタ詳細表示と監視登録は行わない。
+        if !rule.enabled {
+            continue;
+        }
 
         // 包含ファイルフィルタ
         if let Some(pats) = &rule.watch.patterns {
@@ -117,13 +120,16 @@ pub async fn start_watching(
         })?;
     }
 
-    let (compiled_rules, rule_log_handles) = crate::router::compile_rules(rules, global)?;
-    crate::router::run_router(rx, &compiled_rules, global, Arc::clone(&log)).await?;
+    let (compiled_rules, rule_log_handles) = crate::router::compile_rules(rules)?;
+    crate::router::run_router(rx, &compiled_rules, retry, Arc::clone(&log)).await?;
 
-    // ルール別ロガーをシャットダウン
+    // ルール別ロガー（検知・アクション）をシャットダウン
     for rule in &compiled_rules {
-        if let Some(rl) = &rule.rule_logger {
-            rl.shutdown();
+        if let Some(dl) = &rule.detect_logger {
+            dl.shutdown();
+        }
+        if let Some(al) = &rule.action_logger {
+            al.shutdown();
         }
     }
     for handle in rule_log_handles {

--- a/doc/log-redesign-notes.md
+++ b/doc/log-redesign-notes.md
@@ -1,0 +1,203 @@
+# ログ構成 再設計メモ
+
+> 2026-06-07 Roze と Claude の設計相談まとめ。実装前の検討段階。
+
+## 背景・目的
+
+- このプログラムは「1つの実行ファイルに複数ルールを定義し、一斉に稼働」させる。
+- 一部ルールを有効/無効にして運用するため、ログも用途別・ルール別に分けたい。
+- 現状はログが事実上1本（`cat-watcher_{DateTime}.log`）＋任意のルール別ログのみ。
+
+## 決定方針（確定）
+
+ログを **目的ごとに3種類** に分け、種類ごとに列構成を変える。
+
+| 種類 | ファイル名（案） | 単位 | 列構成 | 内容 |
+|------|-----------------|------|--------|------|
+| ① システムログ | `system_{Date}.log` | 全体で1本 | 3列 | 起動・ルール状態一覧・ERROR/WARN・終了 |
+| ② 検知ログ | `detect_{rule}_{Date}.log` | ルール別 | （CSV検討中） | 何がいつ検知されたか（全行MATCH） |
+| ③ アクションログ | `action_{rule}_{Date}.log` | ルール別 | ブロック構造 | トリガー単位で処理内容を記録 |
+
+## ① システムログ（ほぼ確定・エラー方針は更新済み）
+
+```
+timestamp(19) │ level(5) │ content
+```
+
+- 起動時にルール一覧を出す。**有効/無効＋watch_path＋events を書く（詳細表示）**。
+- **アクション失敗のエラーは system に出さない**（→ action ログだけに集約・確定）。
+  system に残るのは「ライフサイクル」＋「システム階層のエラー」のみ:
+  - 起動バナー / ルール一覧 / 監視開始サマリ / 終了
+  - 設定読込失敗・ログファイルオープン失敗など**アクション以前の異常**
+- 例:
+  ```
+  2026-06-07 10:00:00 │ INFO  │ cat-watcher 起動  global=global.toml  rules=rules.toml
+  2026-06-07 10:00:00 │ INFO  │ [ルール] csv-backup  有効  watch=C:/watch/csv  events=Create,Modify
+  2026-06-07 10:00:00 │ INFO  │ [ルール] pdf-move    無効
+  2026-06-07 10:00:00 │ INFO  │ 監視開始  有効ルール=2 / 全3件
+  2026-06-07 18:00:00 │ INFO  │ 終了シグナル受信
+  2026-06-07 18:00:00 │ INFO  │ 正常終了
+  ```
+
+## ② 検知ログ（確定）
+
+- 列: `timestamp(19) │ events(22) │ 検知パス`（パイプ区切りの固定幅テーブル形式）
+- **CSV 化は却下**。過去に試して失敗済み（events 複数値の扱いが破綻）。
+  → 既存ログと同じ「罫線テーブル形式」を踏襲する。
+- 例:
+  ```
+  2026-06-07 10:05:30 │ Create               │ C:/watch/csv/data_20260607.csv
+  2026-06-07 10:31:05 │ Create,Rename        │ C:/watch/csv/sales_final.csv
+  ```
+
+## ③ アクションログ（確定）
+
+- 「1検知イベント = 1ブロック」。先頭にセパレータ行（案1ベース）。
+- **セパレータ行の並び**: `ブロック通し番号 → 時刻 → 検知フルパス → トリガーイベント → アクション数`
+  ```
+  ═══ #1  2026-06-07 10:05:30  C:/watch/csv/data_20260607.csv  (Create)  actions=2 ═══
+  ```
+  - ブロック番号 `#N` は検知イベントごとの通し番号（日次ファイル単位でリセット想定）。
+- **内容行は3列**（検知パスはセパレータに移動したのでトリガー列を廃止）:
+  ```
+  timestamp(19) │ index＋処理種別 │ 処理内容
+  ```
+  - **ツリー記号 `├`/`└` は廃止**。`N. 種別`（番号＋ピリオド）形式にする。
+  - **OK / ERROR の結果行も同じ番号を付ける**（`1. copy` ↔ `1. OK` でペア／案A）。
+    どのアクションが成功/失敗したか追跡しやすい。
+  - 結果行の表記: 成功 `1. OK` / 失敗 `1. ERR`（列幅を揃えるため ERROR は ERR に短縮）。
+- 完成イメージ:
+  ```
+  ═══ #1  2026-06-07 10:05:30  C:/watch/csv/data_20260607.csv  (Create)  actions=2 ═══
+  2026-06-07 10:05:30 │ 1. copy │ destination=C:/backup/20260607/  overwrite=true
+  2026-06-07 10:05:31 │ 1. OK   │ コピー完了: C:/backup/20260607/data_20260607.csv
+  2026-06-07 10:05:31 │ 2. cmd  │ shell=powershell  command=Notify.ps1
+  2026-06-07 10:05:32 │ 2. OK   │ 実行完了
+
+  ═══ #2  2026-06-07 10:31:05  C:/watch/csv/sales_final.csv  (Create,Rename)  actions=2 ═══
+  2026-06-07 10:31:05 │ 1. copy │ destination=C:/backup/20260607/  overwrite=true
+  2026-06-07 10:31:06 │ 1. ERR  │ 書き込み権限なし: C:/backup/20260607/
+  ```
+
+## 設定の変更点（案）
+
+- `[rules.log]` の `log_file_name` を廃止し、種類別に分離:
+  - `detect_log_file_name`
+  - `action_log_file_name`
+- **各ログの出力 ON/OFF はルール別に個別設定する（確定）**。例:
+  - `[rules.log]` に `detect_enabled` / `action_enabled`
+- global の `log_file_name` / `log_to_file` をシステムログに再利用するかは
+  全体方針が固まってから決める（後方互換 or 新項目追加）。
+
+## ログ詳細仕様（追加確定）
+
+- **ブロック番号 `#N`**: 左詰め、**ファイルごと（＝日次ローテーション単位）に #1 から振り直す**。
+- **ターミナル出力はログファイルと完全に切り離して設計する**。
+  3ファイルの設計とは別問題として後で扱う（コンソールに何を流すかは別途）。
+- **ログファイル名にプレフィックス規約（detect_/action_/system_）は設けない**。
+  → 各ログのファイル名はユーザーが設定で自由に指定する。
+- **各ログは「ON/OFF」＋「出力先ディレクトリ」＋「ファイル名」を設定で個別指定**できる。
+  - システムログ: global 側で指定
+  - 検知ログ / アクションログ: rules.log 側でルール別に指定
+
+## ログレベルフィルタ（確定）
+
+- **level 指定はシステムログのみ**に効かせる（INFO/WARN/ERROR…）。
+- 検知ログ・アクションログは level なし、**ON/OFF のみ**。
+  - detect は全行 MATCH なので絞る対象がない。
+  - action の「ERRだけ表示」は将来 failure 系ログを足す方が筋が良い（今はやらない）。
+
+## 設定キー名（確定）
+
+セクションを切り、キー名を全ログで統一する。セクション名が「ログ設定」を語るので
+キーの `log_` プレフィックスは外して短くする（`dir` `file_name` など）。
+
+### global.toml — システムログは独立トップレベルセクション `[system_log]`
+
+```toml
+[global]
+retry_count       = 3
+retry_interval_ms = 1000
+
+[system_log]
+enabled   = true
+dir       = "./log"
+file_name = "system_{Date}.log"
+rotation  = "daily"
+level     = "info"          # level はシステムログだけ
+```
+
+### rules.toml — `[rules.log.detect]` / `[rules.log.action]`（global と同じキー構成）
+
+```toml
+[rules.log.detect]
+enabled   = true
+dir       = "./log"
+file_name = "detect_csv-backup_{Date}.log"
+rotation  = "daily"
+
+[rules.log.action]
+enabled   = true
+dir       = "./log"
+file_name = "action_csv-backup_{Date}.log"
+rotation  = "daily"
+```
+
+### キー一覧（統一）
+
+| キー | system_log | detect | action |
+|------|:---:|:---:|:---:|
+| enabled   | ✓ | ✓ | ✓ |
+| dir       | ✓ | ✓ | ✓ |
+| file_name | ✓ | ✓ | ✓ |
+| rotation  | ✓ | ✓ | ✓ |
+| level     | ✓ | ✗ | ✗ |
+
+- ファイル名はユーザー自由指定（プレフィックス規約なし）。例の `detect_`/`action_` は単なる例。
+- **注意**: これは設定フォーマットの破壊的変更。既存 global.toml/rules.toml の移行が必要
+  （旧 `log_*` キー・旧 `[rules.log]` フラット構成からの移行）。テンプレートも更新対象。
+
+## 未決事項（次回相談）
+
+- 実装の段取り（config 構造体の変更、Logger の3系統化、テンプレート/CSV更新、移行）。
+- ターミナル出力の設計（別トピック）。
+
+### 設定ファイル構成について（決着）
+
+- **global.toml / rules.toml の2ファイル構成は維持で確定**。
+- Roze が一時「1ファイルに統合したい」と考えた理由＝2ファイル編集が面倒、というだけ。
+- 2ファイルの利点（rules 単独差し替え／CSVインポートが rules 単独生成前提／
+  後方互換／設定ミスの影響分離）を確認し、現状維持で納得。
+
+## 確定事項の追記
+
+- 検知ログ CSV 化は **却下**（過去に失敗）。罫線テーブル形式で確定。
+- ログ ON/OFF は **ルール別個別設定** で確定。
+- アクションログは **案1（枠線＋ブロック通し番号）** で確定。内容行3列・`N.`番号・`OK`/`ERR`。
+- **アクション失敗エラーは action ログだけに記録**（system に二重出力しない）で確定。
+- システムログはライフサイクル＋システム階層エラーのみ（アクションエラーは載らない）。
+
+---
+
+## 実装ステータス（2026-06-08 完了）
+
+3分割ログを実装し、`cargo test`（159件）緑・Linux 実機 end-to-end 検証済み。
+
+- `config.rs`: `[retry]` / `[system_log]` / `[rules.log.detect]` / `[rules.log.action]`。
+  全構造体に `#[serde(deny_unknown_fields)]`（旧 `[global]` は起動時エラーで停止）。
+- `logger.rs`: 単一 `Logger` + `LogKind`(System/Detect/Action)。
+  `new_system` / `for_detect` / `for_action` の3コンストラクタ。
+  ブロック連番 `block_seq` は日次ローテで #1 リセット。
+- `actions/mod.rs`: `ActionSink`（system＋action 2系統ファンアウト）。
+  アクション失敗は `execute_chain` が `sink.err` で集約（action ログ＋ターミナルのみ）。
+- `router.rs`: `CompiledRule` に `detect_logger` / `action_logger`。
+  検知→detect、ブロック開始→action、結果→ActionSink。
+- ターミナル表示は無改変（System ロガーが全種を受けるがファイルには
+  Info/Warn/Error のみ書く）。
+
+検証結果（Linux）:
+- system ログ＝ライフサイクルのみ／detect ログ＝3列／action ログ＝ブロック構造。
+- コピー失敗時 `1. WARN`×N→`1. ERR` が **action ログにのみ** 記録され、
+  system ログには出ず、ターミナルには ERROR が表示されることを確認。
+
+**残: Win11 実機検証（パス区切り `\`、サービスモード console=false、PowerShell/cmd 失敗）。**


### PR DESCRIPTION
用途別・ルール別にログを追跡しやすくするため、これまで実質1本だった
ログを3種類に分離した。

- システムログ（全体1本）: 起動バナー/ルール一覧/監視開始/終了と
  システム階層のエラー。levelフィルタあり。
- 検知ログ（ルール別）: 検知イベントのみ（timestamp │ events │ パス）。
- アクションログ（ルール別）: 1検知=1ブロック。#N連番は日次でリセット。
  アクション失敗はここにのみ記録（systemへ二重出力しない）。

設定は破壊的変更。global.tomlは[retry]+[system_log]、rules.tomlは
[rules.log.detect]/[rules.log.action]へ。全構造体にdeny_unknown_fieldsを
付け、旧[global]形式は起動時にエラーで停止する。

ターミナル表示は従来どおり無改変（Systemロガーが全種を受信するが、
ファイルにはInfo/Warn/Errorのみ書き出す）。

実装の詳細・設計経緯はdoc/log-redesign-notes.mdに記録。

Closes #46