### PR TITLE
chore: v1.2.2 リリース（バージョンバンプ）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cat-watcher"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "blake3",
  "chrono",

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-watcher"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## 概要

`cat-watcher` のバージョンを 1.2.1 → **1.2.2** に更新します（Cargo.toml + Cargo.lock）。

## マージすると起きること

この PR を main にマージすると `release.yml` が起動し、自動で以下が実行されます:

1. タグ `v1.2.2` の作成
2. Windows (x86_64-pc-windows-msvc) / Linux (x86_64-unknown-linux-gnu) のリリースビルド
3. GitHub Release の作成とバイナリの添付（リリースノート自動生成）

## v1.2.2 に入る主な変更（v1.2.1 以降の main）

- テストコードの別ファイル分離と整理 (#50)
- CI/CD ワークフローの堅牢性改善（`--locked`、リリース再実行の修正など）(#50)
- README 再構成（#51 を先にマージした場合）

`cargo test --locked` がグリーンであることを確認済みです。

> README の PR #51 はドキュメントのみでバイナリに影響しないため、マージ順はどちらが先でも問題ありません。

https://claude.ai/code/session_01QUMJrMn56dHUyC9FZ91hkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUMJrMn56dHUyC9FZ91hkC)_