### PR TITLE
Hide console window on Windows when console logging is disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "unicode-width",
  "walkdir",
  "windows-service",
+ "windows-sys 0.60.2",
  "winres",
 ]
 

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -20,6 +20,7 @@ unicode-width = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.6"
+windows-sys = { version = "0.60", features = ["Win32_System_Console", "Win32_UI_WindowsAndMessaging"] }
 
 [build-dependencies]
 winres = "0.1"

--- a/cat-watcher/src/main.rs
+++ b/cat-watcher/src/main.rs
@@ -171,6 +171,11 @@ async fn run(cli: &Args) -> Result<(), AppError> {
         return Ok(());
     }
 
+    #[cfg(windows)]
+    if !global_config.system_log.console {
+        hide_console_window();
+    }
+
     let (log, log_handle) = logger::Logger::new_system(&global_config.system_log, true)?;
     let log = Arc::new(log);
 
@@ -196,6 +201,18 @@ fn exit_on_err(result: Result<(), AppError>) {
         let ts = Local::now().format("%Y-%m-%d %H:%M:%S");
         eprintln!("{}", format!("[{ts}] [ERROR] {e}").red().bold());
         std::process::exit(1);
+    }
+}
+
+#[cfg(windows)]
+fn hide_console_window() {
+    use windows_sys::Win32::System::Console::GetConsoleWindow;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_HIDE};
+    unsafe {
+        let hwnd = GetConsoleWindow();
+        if !hwnd.is_null() {
+            ShowWindow(hwnd, SW_HIDE);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Added functionality to hide the console window on Windows when console logging is disabled in the configuration, improving the user experience for GUI applications.

## Key Changes
- Added `hide_console_window()` function that uses Windows API to hide the console window when it's not needed
- Integrated console hiding logic into the startup sequence, executed before logger initialization when `system_log.console` is `false`
- Added `windows-sys` dependency with required Windows API features for console and window management

## Implementation Details
- The console hiding is Windows-specific and only compiled when targeting Windows (`#[cfg(windows)]`)
- Uses unsafe Windows API calls (`GetConsoleWindow` and `ShowWindow`) to hide the console window
- The function safely checks if the console window handle is valid before attempting to hide it
- Executes early in the application startup to ensure the console is hidden before any logging occurs

https://claude.ai/code/session_01DdkLRnQmn4tVGuWLXsTpmP