### PR TITLE
chore: v1.2.3 リリース（バージョンバンプ）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cat-watcher"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "blake3",
  "chrono",

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-watcher"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## 概要

`cat-watcher` のバージョンを `1.2.2` → `1.2.3` に上げます。

main へマージされると `.github/workflows/release.yml` が起動し、タグ `v1.2.3` 作成・バイナリビルド・GitHub リリース公開が自動で行われます。

## 変更内容

- `cat-watcher/Cargo.toml`: version `1.2.2` → `1.2.3`
- `Cargo.lock`: 同上に同期

## 関連

- このリリースには #49（`console=false` のときコンソールウィンドウを非表示にする / PR #54 でマージ済み）が含まれます。

https://claude.ai/code/session_01FZiUFoHb6V1PsVUk47TPjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZiUFoHb6V1PsVUk47TPjY)_