### PR TITLE
feat(dashboard): ダッシュボードを既定ビルドに同梱＋Windowsサービス起動に対応 (v1.2.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
       - name: テスト実行
         run: cargo test --locked --manifest-path cat-watcher/Cargo.toml
 
-      # 既定ビルドには含まれない dashboard feature もコンパイルを検証する
-      - name: ダッシュボード feature ビルド確認
-        run: cargo build --locked --features dashboard --manifest-path cat-watcher/Cargo.toml
+      # dashboard は既定で同梱。--no-default-features の最小ビルドが壊れていないかも検証する
+      - name: 最小ビルド確認（--no-default-features）
+        run: cargo build --locked --no-default-features --manifest-path cat-watcher/Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cat-watcher"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "blake3",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@
 cargo build --release --locked --manifest-path cat-watcher/Cargo.toml
 ```
 
-[ダッシュボード](#ダッシュボードブラウザでリアルタイム表示)（ブラウザでのリアルタイム表示）を使う場合は `dashboard` feature を付けてビルドします（任意・既定は無効）：
+[ダッシュボード](#ダッシュボードブラウザでリアルタイム表示)（ブラウザでのリアルタイム表示）は**既定で同梱**されます。スリムにしたい場合のみ `--no-default-features` で外せます：
 
 ```bash
-cargo build --release --locked --features dashboard --manifest-path cat-watcher/Cargo.toml
+cargo build --release --locked --no-default-features --manifest-path cat-watcher/Cargo.toml
 ```
 
 ## クイックスタート
@@ -386,11 +386,7 @@ Windows / Linux 共通の挙動です。
 
 ### ビルドと有効化
 
-機能を使うには `dashboard` feature 付きでビルドします（任意・既定は無効）。
-
-```bash
-cargo build --release --locked --features dashboard --manifest-path cat-watcher/Cargo.toml
-```
+ダッシュボードは**既定ビルドに同梱**されています（`cargo build` でそのまま含まれ、リリースのバイナリにも入ります）。不要なら `--no-default-features` で外せます。
 
 `global.toml` に `[dashboard]` を追加し `enabled = true` にすると、監視の起動と同時に
 ローカル HTTP サーバが立ち上がります。
@@ -416,7 +412,7 @@ history = 200               # 接続時にブラウザへ再生する直近イ�
 - **セキュリティ**: 既定は `127.0.0.1`（ローカルのみ）。ログにはファイルパスが
   含まれるため、外部公開は慎重に。リモートで見たい場合は SSH トンネルや
   リバースプロキシ経由を推奨します（本体に認証・TLS はありません）。
-- feature 無しでビルドした場合、`[dashboard]` セクションを書いても無視されます
+- `--no-default-features` でビルドした場合、`[dashboard]` セクションを書いても無視されます
   （設定エラーにはなりません）。
 
 ## 常駐化（サービス登録）

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "cat-watcher"
-version = "1.2.4"
+version = "1.2.5"
 edition = "2021"
 
 [features]
-default = []
-# ブラウザでログをリアルタイム表示するダッシュボード（localhost HTTP + SSE）。
-# 既定 OFF。追加依存は serde_json と tokio/net のみ。
+# ダッシュボード（ブラウザでログをリアルタイム表示・localhost HTTP + SSE）を
+# 既定で同梱する。スリムにしたい場合は --no-default-features で外せる。
+default = ["dashboard"]
+# 追加依存は serde_json と tokio/net のみ。
 dashboard = ["dep:serde_json", "tokio/net"]
 
 [dependencies]

--- a/cat-watcher/src/dashboard.rs
+++ b/cat-watcher/src/dashboard.rs
@@ -206,6 +206,48 @@ pub fn publish(mut ev: DashEvent) {
     let _ = hub.tx.send(ev);
 }
 
+/// 設定からダッシュボードを初期化し、HTTP/SSE サーバを別タスクで起動する。
+/// `dashboard` が未設定 / `enabled=false` のときは何もしない。
+/// CLI 起動（`main`）と Windows サービス起動（`service`）の両方から呼ぶ共通入口。
+/// tokio ランタイム上で呼ぶこと（内部で `tokio::spawn` する）。
+pub fn start(global: &crate::config::GlobalConfig, rules: &[crate::config::Rule], log: Arc<Logger>) {
+    let Some(dash) = &global.dashboard else { return };
+    if !dash.enabled {
+        return;
+    }
+    // 過去ログ検索の対象を設定から集める（システムログ＋有効なルール別ログ）。
+    let mut sources = vec![LogSource {
+        kind: "system",
+        dir: global.system_log.dir.clone(),
+        file_name: global.system_log.file_name.clone(),
+    }];
+    for rule in rules {
+        if let Some(rule_log) = &rule.log {
+            if let Some(detect) = &rule_log.detect {
+                if detect.enabled {
+                    sources.push(LogSource {
+                        kind: "detect",
+                        dir: detect.dir.clone(),
+                        file_name: detect.file_name.clone(),
+                    });
+                }
+            }
+            if let Some(action) = &rule_log.action {
+                if action.enabled {
+                    sources.push(LogSource {
+                        kind: "action",
+                        dir: action.dir.clone(),
+                        file_name: action.file_name.clone(),
+                    });
+                }
+            }
+        }
+    }
+    init(dash.history, sources);
+    let bind = dash.bind.clone();
+    tokio::spawn(async move { serve(bind, log).await });
+}
+
 /// HTTP/SSE サーバを起動する。`bind` は `"127.0.0.1:8080"` 形式。
 /// 失敗してもプロセスは落とさず、system ログに記録して戻る。
 pub async fn serve(bind: String, log: Arc<Logger>) {

--- a/cat-watcher/src/main.rs
+++ b/cat-watcher/src/main.rs
@@ -187,45 +187,10 @@ async fn run(cli: &Args) -> Result<(), AppError> {
         rules_path.display()
     ));
 
-    // ダッシュボード（任意・既定 OFF・dashboard feature 有効時のみ）。
+    // ダッシュボード（既定で同梱・設定 enabled=true のときだけ起動）。
     // 監視を開始する前にハブを初期化し、HTTP/SSE サーバを別タスクで起動する。
     #[cfg(feature = "dashboard")]
-    if let Some(dash) = &global_config.dashboard {
-        if dash.enabled {
-            // 過去ログ検索の対象を設定から集める（システムログ＋有効なルール別ログ）。
-            let mut sources = vec![dashboard::LogSource {
-                kind: "system",
-                dir: global_config.system_log.dir.clone(),
-                file_name: global_config.system_log.file_name.clone(),
-            }];
-            for rule in &rules_conf.rules {
-                if let Some(rule_log) = &rule.log {
-                    if let Some(detect) = &rule_log.detect {
-                        if detect.enabled {
-                            sources.push(dashboard::LogSource {
-                                kind: "detect",
-                                dir: detect.dir.clone(),
-                                file_name: detect.file_name.clone(),
-                            });
-                        }
-                    }
-                    if let Some(action) = &rule_log.action {
-                        if action.enabled {
-                            sources.push(dashboard::LogSource {
-                                kind: "action",
-                                dir: action.dir.clone(),
-                                file_name: action.file_name.clone(),
-                            });
-                        }
-                    }
-                }
-            }
-            dashboard::init(dash.history, sources);
-            let bind = dash.bind.clone();
-            let dlog = Arc::clone(&log);
-            tokio::spawn(async move { dashboard::serve(bind, dlog).await; });
-        }
-    }
+    dashboard::start(&global_config, &rules_conf.rules, Arc::clone(&log));
 
     let result = watcher::start_watching(&rules_conf.rules, &global_config.retry, Arc::clone(&log)).await;
     if let Err(e) = &result {

--- a/cat-watcher/src/service.rs
+++ b/cat-watcher/src/service.rs
@@ -128,6 +128,11 @@ fn run_watcher(
 
         log.info("Windowsサービスとして起動しました".to_string());
 
+        // ダッシュボード（既定で同梱）。サービス常駐でもブラウザから閲覧できるよう、
+        // CLI 起動と同じ共通入口でローカル HTTP/SSE サーバを起動する。
+        #[cfg(feature = "dashboard")]
+        crate::dashboard::start(&global_config, &rules_conf.rules, Arc::clone(&log));
+
         let result = tokio::select! {
             result = watcher::start_watching(&rules_conf.rules, &global_config.retry, Arc::clone(&log)) => result,
             _ = stop_rx => {

--- a/cat-watcher/src/templates.rs
+++ b/cat-watcher/src/templates.rs
@@ -17,7 +17,7 @@ console   = true                  # コンソールへの出力 ON/OFF
 # ─── ダッシュボード（ブラウザでログをリアルタイム表示）─────────────────
 # enabled = true でローカル HTTP サーバを起動し、ブラウザの
 #   http://127.0.0.1:8080/  で検知/アクション/システムログをライブ表示します。
-#   ※ 動作には dashboard feature 付きビルドが必要: cargo build --release --features dashboard
+#   ※ 既定ビルドに同梱（enabled=false なら起動しません）。
 #   ※ bind はローカル限定を推奨（ログにファイルパスが出ます。外部公開は慎重に）。
 [dashboard]
 enabled = false


### PR DESCRIPTION
## 概要

ダッシュボードを **既定ビルドに同梱** し、**Windows サービス起動時にも立ち上がる** よう修正します（v1.2.5）。

## 背景 / 動機

v1.2.4 でダッシュボード機能自体はマージ済みでしたが、配布バイナリでは動作しませんでした。原因は 2 点：

1. **既定 OFF の Cargo feature だった** — `release.yml` は `--features dashboard` 無しでビルドするため、リリースの exe にダッシュボードが **コンパイルされていなかった**（入っていないのと同じ状態）。
2. **Windows サービス経路で起動していなかった** — `service.rs::run_watcher` に起動処理が無く、CLI 起動時しかダッシュボードが立ち上がらなかった（常駐ユースケースが本命なのに）。

## 変更点

- **`Cargo.toml`**: `default = ["dashboard"]` に変更 → `cargo build` / リリースビルドに自動同梱。
- **`service.rs`**: サービス経路でも `dashboard::start()` を呼ぶよう修正。CLI と共通の起動入口に一本化（`main` / `service` 双方から呼ぶ）。
- **`ci.yml`**: 既定で dashboard を含むため、検証ステップを `--no-default-features`（最小ビルド）に変更。
- テンプレート / README を「既定同梱」前提に更新。
- バージョン **1.2.5**。

## 互換性

- `[dashboard] enabled = true` のときだけ起動する点は **不変**（既定挙動は変わらない・勝手には立ち上がらない）。
- `--no-default-features` で **従来どおり除外可能**（スリムビルド維持）。

## 検証

- ローカル（Linux）: 既定ビルド・テスト（71 件）・`--no-default-features` ビルド・clippy すべて green。
- **Windows サービス経路（`service.rs`）は Linux ではコンパイル対象外** のため、本 PR の CI（windows-latest の `cargo test`、ダッシュボード既定込み）で検証されます。

## リリース

main へマージすると `release.yml` が **v1.2.5** を生成します（ダッシュボード同梱の Win / Linux バイナリ）。これで配布 exe で実際にダッシュボードが使えるようになります（サービス常駐時を含む）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121btTQa51jcMtLAXDdXsHp

---
_Generated by [Claude Code](https://claude.ai/code/session_0121btTQa51jcMtLAXDdXsHp)_