### PR TITLE
chore: v1.3.1 リリース（バージョンバンプ）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cat-watcher"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "blake3",
  "chrono",

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-watcher"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
## 概要

`cat-watcher` のバージョンを `1.3.0` → **`1.3.1`** に上げます。

main へマージすると `.github/workflows/release.yml` が起動し、以下が自動実行されます:

1. タグ `v1.3.1` の作成
2. Windows (x86_64-pc-windows-msvc) / Linux (x86_64-unknown-linux-gnu) のリリースビルド
3. GitHub Release の作成とバイナリ添付

## 変更内容

- `cat-watcher/Cargo.toml`: version `1.3.0` → `1.3.1`
- `Cargo.lock`: 同期

## v1.3.1 に含まれる主な変更（v1.3.0 以降の main）

- **#62** feat(service): 外部プロセスをログオンユーザー権限で実行できるようにする

> ℹ️ リファクタ PR #63（モジュールのディレクトリ分割・挙動不変）は本リリースとは独立です。
> このリリースより前にマージすれば v1.3.1 のバイナリにも含まれますが、挙動には影響しません。

`cargo build --locked` がグリーンであることを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGskWrvKoVyYi7hhdMmxbh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGskWrvKoVyYi7hhdMmxbh)_