### PR TITLE
ci: CI を PR と main への push のみで実行（無駄打ち削減）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,19 @@
 name: CI
 
+# 無駄打ち削減: 毎プッシュでは回さず、PR（作成/更新）と main への push のみで実行する。
+# - ブランチへの中間 WIP プッシュでは走らない（PR を開けば検証される）。
+# - ドキュメントのみの変更（*.md / doc/）は重いビルド/テストをスキップする。
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'doc/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'doc/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## 概要

CI の無駄打ちを減らすため、トリガーを見直します。

これまで `ci.yml` は **main 以外への全プッシュ** で走っていたため、ブランチへの中間 WIP プッシュごとに Win/Linux マトリクスが回り無駄が多くありました。

## 変更点

- トリガーを **PR（作成/更新）** と **main への push** のみに限定。
  - ブランチへの中間プッシュでは走らない（PR を開けば検証される）。
  - PR 単位なので、従来の「push イベント + PR イベント」での二重実行も解消。
- **docs のみの変更**（`**.md` / `doc/**`）は重いビルド/テストを **スキップ**（`paths-ignore`）。

## 維持する安全網

- **Win/Linux 両OSのテストマトリクスは PR 時に維持**。
  このプロジェクトは Windows 専用コード（`service` / `win_runas`）が多く、Windows CI を削ると Windows 限定の壊れを検知できなくなるため、ここは削っていません。
- `--no-default-features` の最小ビルド確認も従来どおり。
- リリース（バイナリビルド）は `release.yml` が main への push 時に担当（変更なし）。

> ℹ️ もし main のブランチ保護で「テスト」チェックを必須にしている場合、docs のみの PR は CI がスキップされてチェック待ちになることがあります。必須化している場合は教えてください（その場合は別方式に切り替えます）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGskWrvKoVyYi7hhdMmxbh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGskWrvKoVyYi7hhdMmxbh)_