### PR TITLE
build: Windows バイナリを CRT 静的リンクで単体動作化（v1.3.2）

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+# Windows(MSVC) ビルドでは C ランタイム(CRT)を実行ファイルに静的リンクする。
+#
+# 既定の動的リンクだと、実行する PC 側に Visual C++ 再頒布可能パッケージ
+# (VCRUNTIME140.dll / MSVCP140.dll など) が必要になり、まっさらな Windows では
+# 「VCRUNTIME140.dll が見つからない」エラーで起動できない。
+# crt-static を付けるとランタイムが exe に同梱され、追加インストール不要で
+# どの Windows でも単体で動く（実行ファイルは少し大きくなる）。
+#
+# scope は MSVC ターゲットのみ。Linux(gnu) では crt-static は glibc の静的リンクを
+# 意味し望ましくないため、cfg で Windows/MSVC に限定する。
+# blake3 等の C コードをビルドする cc クレートもこのフラグを検知して /MT を使うため、
+# Rust 側と C 側で CRT のリンク方式が揃う。
+[target.'cfg(target_env = "msvc")']
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cat-watcher"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "blake3",
  "chrono",

--- a/cat-watcher/Cargo.toml
+++ b/cat-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cat-watcher"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
## 概要

Windows 向け `cat-watcher.exe` を **Visual C++ 再頒布可能パッケージ不要の単体 exe** にします。あわせてパッチバージョンを `1.3.1 → 1.3.2` に上げ、配布リリースへ反映します。

## 背景 / 問題

既定の動的リンク（MSVC）でビルドした exe は `VCRUNTIME140.dll` / `MSVCP140.dll` などの VC++ ランタイムに依存します。これらが未インストールのまっさらな Windows（新規 VM など）では、以下のエラーで起動できませんでした:

> VCRUNTIME140.dll が見つからないため、コードの実行を続行できません。

## 変更内容

- `.cargo/config.toml` を新規追加し、**MSVC ターゲットのみ** CRT を静的リンク:

  ```toml
  [target.'cfg(target_env = "msvc")']
  rustflags = ["-C", "target-feature=+crt-static"]
  ```

  - ランタイムが exe に同梱され、追加インストール不要でどの Windows でも単体起動する。
  - `cfg(target_env = "msvc")` で限定するため **Linux(gnu) ビルドには無影響**（gnu で crt-static は glibc 静的リンクを意味し望ましくないため）。
  - `blake3` 等の C コードをビルドする `cc` クレートも crt-static を検知して `/MT` を使い、Rust 側と CRT のリンク方式が揃う。
- `cat-watcher/Cargo.toml` / `Cargo.lock` のバージョンを `1.3.2` に更新。

## 効果

- VC++ 再頒布パッケージのインストール不要で `.exe` 単体動作。
- 残る依存は全 Windows に必ず存在するシステム DLL（`kernel32` 等）のみ（静的リンク不可能な OS API 面で、これは正常）。
- `doc/requirements.md` / `doc/specification.md` が以前から記載していた「追加ランタイム不要・単一 exe で動作」を、実態として初めて満たす。

## 検証

- `.cargo/config.toml` のパースを `cargo metadata` で確認 ✅
- Linux で `cargo build -p cat-watcher` 成功（config の影響を受けず従来どおり）✅
- `Cargo.lock` 更新後、`--locked` 整合を確認 ✅
- Windows MSVC ビルドでの静的リンク反映は、本 PR の release/CI（`windows-latest`, `x86_64-pc-windows-msvc`）で検証されます。

## リリース

main マージ後、`release.yml` が `v1.3.2` タグとリリースを作成し、**依存ゼロの Windows バイナリ**が配布されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EE3ve2ouAbjzvy18o7gyDi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EE3ve2ouAbjzvy18o7gyDi)_